### PR TITLE
Add support for source-context

### DIFF
--- a/lib/debugletapi.js
+++ b/lib/debugletapi.js
@@ -16,8 +16,12 @@
 
 'use strict';
 
-var utils = require('@google/cloud-diagnostics-common').utils;
+var fs = require('fs')
+var path = require('path');
 var assert = require('assert');
+var crypto = require('crypto');
+var pjson = require('../package.json');
+var utils = require('@google/cloud-diagnostics-common').utils;
 var StatusMessage = require('./apiclasses.js').StatusMessage;
 
 /** @const {string} Cloud Debug API endpoint */
@@ -62,7 +66,16 @@ DebugletApi.prototype.init = function(uid, callback) {
       return;
     }
     that.projectNumber_ = projectNumber;
-    callback(null);
+
+    fs.readFile('source-context.json', 'utf8', function(err, data) {
+      try {
+        that.sourceContext_ = JSON.parse(data);
+      } catch (e) {
+        // TODO: log a warning.
+        // But we keep on going.
+      }
+      callback(null);
+    });
   }
 
   if (process.env.GCLOUD_PROJECT_NUM) {
@@ -102,21 +115,31 @@ DebugletApi.prototype.registerError = function(message) {
 DebugletApi.prototype.register_ = function(errorMessage, callback) {
   var that = this;
 
-  var pjson = require('../package.json');
+  var cwd = process.cwd();
+  var mainScript = path.relative(cwd, process.argv[1]);
 
   var version = 'google.com/node/' + pjson.version;
-  var desc = process.title + ' ' + process.argv[1];
-  var uniquifier = desc + version + that.uid_;
-  uniquifier  = require('crypto')
-                  .createHash('sha1')
-                  .update(uniquifier)
-                  .digest('hex');
+  var desc = process.title + ' ' + mainScript;
+  var labels = {
+    'main script': mainScript,
+    'working directory': cwd,
+    'process.title': process.title,
+    'node version': process.versions.node,
+    'V8 version': process.versions.v8,
+    'agent.name': pjson.name,
+    'agent.version': pjson.version
+  };
+  var uniquifier = desc + version + that.uid_ + that.sourceContext_ +
+    JSON.stringify(labels);
+  uniquifier  = crypto.createHash('sha1').update(uniquifier).digest('hex');
 
   var debuggee = {
     project: that.projectNumber_,
     uniquifier: uniquifier,
     description: desc,
-    agentVersion: version
+    agentVersion: version,
+    labels: labels,
+    sourceContexts: [that.sourceContext_]
   };
 
   if (errorMessage) {
@@ -205,7 +228,10 @@ DebugletApi.prototype.updateBreakpoint =
       }
     };
 
-    // TODO(ofrobots): is the try-catch necessary here?
+    // We need to have a try/catch here because a JSON.stringify will be done
+    // by request. Some V8 debug mirror objects get a throw when we attempt to
+    // stringify them. The try-catch keeps it resilient and avoids crashing the
+    // user's app.
     try {
       this.request_(options, function(err, response, body) {
         callback(err, body);


### PR DESCRIPTION
Fixes: https://github.com/GoogleCloudPlatform/cloud-debug-nodejs/issues/3

gcloud cli generates a source-context.json file on deployment. This works for
Java already, but is expected to start working for Node.js as well as per some
work being done by the Cloud Debug team.

There are no tests available at the moment, but I will add them as a follow-on. This is tracked by: https://github.com/GoogleCloudPlatform/cloud-debug-nodejs/issues/15
