### PR TITLE
add GAE module and version labels

### DIFF
--- a/lib/debugletapi.js
+++ b/lib/debugletapi.js
@@ -16,7 +16,7 @@
 
 'use strict';
 
-var fs = require('fs')
+var fs = require('fs');
 var path = require('path');
 var assert = require('assert');
 var crypto = require('crypto');
@@ -26,6 +26,11 @@ var StatusMessage = require('./apiclasses.js').StatusMessage;
 
 /** @const {string} Cloud Debug API endpoint */
 var API = 'https://clouddebugger.googleapis.com/v2/controller';
+
+/* c.f. the Java Debugger agent */
+/** @const {string} */ var DEBUGGEE_MODULE_LABEL = 'module';
+/** @const {string} */ var DEBUGGEE_MAJOR_VERSION_LABEL = 'version';
+/** @const {string} */ var DEBUGGEE_MINOR_VERSION_LABEL = 'minorversion';
 
 /** @const {Array<string>} list of scopes needed to operate with the debug API */
 var SCOPES = [
@@ -122,13 +127,27 @@ DebugletApi.prototype.register_ = function(errorMessage, callback) {
   var desc = process.title + ' ' + mainScript;
   var labels = {
     'main script': mainScript,
-    'working directory': cwd,
     'process.title': process.title,
     'node version': process.versions.node,
     'V8 version': process.versions.v8,
     'agent.name': pjson.name,
     'agent.version': pjson.version
   };
+
+  if (process.env.GAE_MODULE_NAME) {
+    desc += ' module:' + process.env.GAE_MODULE_NAME;
+    labels[DEBUGGEE_MODULE_LABEL] = process.env.GAE_MODULE_NAME;
+  }
+
+  if (process.env.GAE_MODULE_VERSION) {
+    desc += ' version:' + process.env.GAE_MODULE_VERSION;
+    labels[DEBUGGEE_MAJOR_VERSION_LABEL] = process.env.GAE_MODULE_VERSION;
+  }
+
+  if (process.env.GAE_MINOR_VERSION) {
+    labels[DEBUGGEE_MINOR_VERSION_LABEL] = process.env.GAE_MINOR_VERSION;
+  }
+
   var uniquifier = desc + version + that.uid_ + that.sourceContext_ +
     JSON.stringify(labels);
   uniquifier  = crypto.createHash('sha1').update(uniquifier).digest('hex');


### PR DESCRIPTION
When running on GAE, we should provide GAE module name and versions to the labels.

Removed the working directory as label is it is debatable if processes launched from different working directories should be considered different debuggees (all else being equal).

@matthewloring PTAL.
