### PR TITLE
add support for V8 4.6

### DIFF
--- a/lib/v8debugapi.js
+++ b/lib/v8debugapi.js
@@ -54,6 +54,7 @@ module.exports.create = function(logger_, config_) {
   var breakpoints = {};
   var listeners = {};
   var numBreakpoints = 0;
+  var usePermanentListener = true;
 
   // Node.js v0.11+ have the runInDebugContext method that can be used to fetch
   // the API object.
@@ -61,11 +62,31 @@ module.exports.create = function(logger_, config_) {
     return null;
   }
 
+  // Before V8 4.6, having a debug listener active disables optimization. To
+  // deal with this we only activate the listener when there is a breakpoint
+  // active, and remote it as soon as the snapshot is taken. Furthermore, 4.6
+  // changes the API such that Debug.scripts() crashes unless a listener is
+  // active. We use a permanent listener on V8 4.6+.
+  var result = /(\d+)\.(\d+)\.\d+\.\d+/.exec(process.versions.v8);
+  if (!result) {
+    // malformed V8 version?
+    return null;
+  }
+  if (parseInt(result[1], 10) < 4 ||
+      parseInt(result[2], 10) < 6) {
+    usePermanentListener = false;
+  }
+
   v8 = vm.runInDebugContext('Debug');
   logger = logger_;
   config = config_;
   emitter = new events.EventEmitter();
   emitter.setMaxListeners(0);
+
+  if (usePermanentListener) {
+    logger.info('activating v8 breakpoint listener (permanent)');
+    v8.setListener(handleDebugEvents);
+  }
 
   /* -- Public Interface -- */
 
@@ -143,7 +164,7 @@ module.exports.create = function(logger_, config_) {
       delete breakpoints[breakpoint.id];
       delete listeners[breakpoint.id];
       numBreakpoints--;
-      if (numBreakpoints === 0) {
+      if (numBreakpoints === 0 && !usePermanentListener) {
         // removed last breakpoint
         logger.info('deactivating v8 breakpoint listener');
         v8.setListener(null);
@@ -260,7 +281,7 @@ module.exports.create = function(logger_, config_) {
         messages.V8_BREAKPOINT_ERROR);
     }
 
-    if (numBreakpoints === 0) {
+    if (numBreakpoints === 0 && !usePermanentListener) {
       // added first breakpoint
       logger.info('activating v8 breakpoint listener');
       v8.setListener(handleDebugEvents);


### PR DESCRIPTION
Debug.scripts() API changed in 4.6 such that it crashes with an 'illegal access'
unless a listener is active. We deal with this by keeping a permanent listener
with V8 4.6+ given that the performance issues with the listener have been fixed
in 4.6.
