### PR TITLE
Debug.scripts API changed in V8 4.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: node_js
 
 node_js:
   - "0.12"
-  - "0.10"
-  - "iojs"
+  - "2"
+  - "4"
 

--- a/lib/v8debugapi.js
+++ b/lib/v8debugapi.js
@@ -73,7 +73,7 @@ module.exports.create = function(logger_, config_) {
     return null;
   }
   if (parseInt(result[1], 10) < 4 ||
-      parseInt(result[2], 10) < 6) {
+      parseInt(result[2], 10) < 5) {
     usePermanentListener = false;
   }
 


### PR DESCRIPTION
This is causing us to break with Node 4.x: https://travis-ci.org/GoogleCloudPlatform/cloud-debug-nodejs/jobs/81499758