### PR TITLE
fix problem with server breakpoint deletion

### DIFF
--- a/lib/debuglet.js
+++ b/lib/debuglet.js
@@ -202,15 +202,13 @@ Debuglet.prototype.scheduleBreakpointFetch_ = function(seconds) {
           return;
 
         case 409: // Timeout on a hanging GET.
-          that.logger_.info('\t409 Hanging GET completed, no change.');
+          that.logger_.info('\t409 Long poll completed.');
           that.scheduleBreakpointFetch_(0/*immediately*/);
           return;
 
         default:
           that.logger_.info('\t' + response.statusCode + ' completed.');
-          if (body.breakpoints) {
-            that.updateActiveBreakpoints_(body.breakpoints || []);
-          }
+          that.updateActiveBreakpoints_(body.breakpoints || []);
           if (Object.keys(that.activeBreakpointMap_).length) {
             that.logger_.breakpoints(Logger.INFO, 'Active Breakpoints:',
               that.activeBreakpointMap_);
@@ -229,9 +227,11 @@ Debuglet.prototype.scheduleBreakpointFetch_ = function(seconds) {
  */
 Debuglet.prototype.updateActiveBreakpoints_ = function(breakpoints) {
   var that = this;
-
   var updatedBreakpointMap = this.convertBreakpointListToMap_(breakpoints);
-  that.logger_.breakpoints(Logger.INFO, 'Server breakpoints:', updatedBreakpointMap);
+
+  if (breakpoints.length) {
+    that.logger_.breakpoints(Logger.INFO, 'Server breakpoints:', updatedBreakpointMap);
+  }
 
   breakpoints.forEach(function(breakpoint) {
 
@@ -280,6 +280,7 @@ Debuglet.prototype.convertBreakpointListToMap_ = function(breakpointList) {
  * @private
  */
 Debuglet.prototype.removeBreakpoint_ = function(breakpoint) {
+  this.logger_.info('\tdeleted breakpoint', breakpoint.id);
   delete this.activeBreakpointMap_[breakpoint.id];
   if (this.v8debug_) {
     this.v8debug_.clear(breakpoint);
@@ -336,8 +337,7 @@ Debuglet.prototype.addBreakpoint_ = function(breakpoint, cb) {
 Debuglet.prototype.completeBreakpoint_ = function(breakpoint) {
   var that = this;
 
-  that.logger_.breakpoint(Logger.INFO,
-    'Updating breakpoint data on server', breakpoint);
+  that.logger_.info('\tupdating breakpoint data on server', breakpoint.id);
   // TODO: in case of transient errors, retry the update operation
   // Put in the completed breakpoints map only when the update successfully
   // completes. Otherwise - we refuse to set the breakpoint, but the server

--- a/lib/debugletapi.js
+++ b/lib/debugletapi.js
@@ -206,7 +206,7 @@ DebugletApi.prototype.listBreakpoints = function(callback) {
     if (!response) {
       callback(err || new Error('unknown error - request response missing'));
       return;
-    } else if (response.statusCode === 409) { // indicates timeout
+    } else if (response.statusCode === 409) { // indicates end of a hanging GET
       callback(null, response);
       return;
     } else if (response.statusCode === 404) {


### PR DESCRIPTION
We were failing to notice when the last server breakpoint got deleted. As a
result we were keeping the V8 breakpoint, and the event listener active forever.
This was a performance problem.

I improved some log messages at the same time, while I was debugging.

@matthewloring PTAL.