### PR TITLE
Add coverage and dependency tracking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ node_js:
   - "2"
   - "4"
 
+after_success:
+  - ./bin/run-coverage.sh

--- a/README.md
+++ b/README.md
@@ -1,8 +1,25 @@
 # Node.js agent for Google Cloud Debug
 
+[![NPM Version][npm-image]][npm-url]
+[![Build Status][travis-image]][travis-url]
+[![Test Coverage][coveralls-image]][coveralls-url]
+[![Dependency Status][david-image]][david-url]
+[![devDependency Status][david-dev-image]][david-dev-url]
+
 This module implements experimental support for Google
 [Cloud Debugger](https://cloud.google.com/tools/cloud-debugger/) for Node.js.
 This module is experimental and not suitable for production use at this point.
 
 This module uses APIs there may be undocumented and are not covered by any
 deprecation policy, and this may be subject to change without notice.
+
+[npm-image]: https://img.shields.io/npm/v/@google/cloud-debug.svg
+[npm-url]: https://npmjs.org/package/@google/cloud-debug
+[travis-image]: https://travis-ci.org/GoogleCloudPlatform/cloud-debug-nodejs.svg?branch=master
+[travis-url]: https://travis-ci.org/GoogleCloudPlatform/cloud-debug-nodejs
+[coveralls-image]: https://img.shields.io/coveralls/GoogleCloudPlatform/cloud-debug-nodejs/master.svg
+[coveralls-url]: https://coveralls.io/r/GoogleCloudPlatform/cloud-debug-nodejs?branch=master
+[david-image]: https://david-dm.org/GoogleCloudPlatform/cloud-debug-nodejs.svg
+[david-url]: https://david-dm.org/GoogleCloudPlatform/cloud-debug-nodejs
+[david-dev-image]: https://david-dm.org/GoogleCloudPlatform/cloud-debug-nodejs/dev-status.svg
+[david-dev-url]: https://david-dm.org/GoogleCloudPlatform/cloud-debug-nodejs#info=devDependencies

--- a/bin/run-bump.sh
+++ b/bin/run-bump.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+read -p "Press enter to bump to version $1 and push to $2" -n 1 -r
+git checkout master || exit 1
+git fetch -v "$2" || exit 1
+git rebase "$2/master" || exit 1
+npm version "$1" || exit 1
+git push "$2" master --tags || exit 1
+npm publish

--- a/bin/run-coverage.sh
+++ b/bin/run-coverage.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+istanbul cover $(npm bin)/_mocha --report lcovonly -- test --timeout 4000 --R spec
+cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+rm -rf ./coverage

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+jshint . || exit 1
+istanbul test $(npm bin)/_mocha -- test --timeout 4000 --R spec || exit 1

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": "index.js",
   "repository": "GoogleCloudPlatform/cloud-debug-nodejs",
   "scripts": {
-    "test": "jshint . && istanbul test ./node_modules/.bin/_mocha -- test --timeout 4000 --R spec",
-    "coverage": "istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- test --timeout 4000 --R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
+    "test": "./bin/run-test.sh",
+    "coverage": "./bin/run-coverage.sh",
+    "bump": "./bin/run-bump.sh",
     "closure": "./node_modules/.bin/closure-npc"
   },
   "keywords": [

--- a/pre-push
+++ b/pre-push
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-npm test || exit 1
-for test in test/hooks/test-*.js ;
-do
-  $(npm bin)/mocha ${test} || exit 1
-done


### PR DESCRIPTION
This patch adds version number, coverage, and
dependency tracking badges to the readme. It
also introduces scripts for managing tests/
coverage/versioning and removes the no longer
used prepush hooks.

Fixes #5
Fixes #6