### PR TITLE
Do not modify protobuf breakpoint message

### DIFF
--- a/lib/v8debugapi.js
+++ b/lib/v8debugapi.js
@@ -125,7 +125,7 @@ module.exports.create = function(logger_, config_, fileStats_) {
           source: scriptPath.indexOf('/') === -1 ? scriptPath
             : scriptPath.split('/').pop(),
           line: breakpoint.location.line,
-          column: 0
+          column: 0 // unlike lines, columns are 0-indexed for source-map ಠ_ಠ.
         };
         compile = getBreakpointCompiler(breakpoint);
         if (breakpoint.condition && compile) {
@@ -269,17 +269,19 @@ module.exports.create = function(logger_, config_, fileStats_) {
         messages.INVALID_LINE_NUMBER);
     }
 
-    breakpoint.location.column = breakpoint.location.column || 1;
+    // The breakpoint protobuf message presently doesn't have a column property
+    // but it may have one in the future.
+    var column = breakpoint.location.column || 1;
+    var line = breakpoint.location.line;
 
     // We need to special case breakpoints on the first line. Since Node.js
     // wraps modules with a function expression, we adjust
     // to deal with that.
-    if (breakpoint.location.line === 1) {
-      breakpoint.location.column += MODULE_WRAP_PREFIX_LENGTH - 1;
+    if (line === 1) {
+      column += MODULE_WRAP_PREFIX_LENGTH - 1;
     }
 
-    var v8bp = setByRegExp(scriptPath, breakpoint.location.line,
-      breakpoint.location.column);
+    var v8bp = setByRegExp(scriptPath, line, column);
     if (!v8bp) {
       return setErrorStatusAndCallback(cb, breakpoint,
         StatusMessage.BREAKPOINT_SOURCE_LOCATION,

--- a/test/test-v8debugapi.js
+++ b/test/test-v8debugapi.js
@@ -477,18 +477,6 @@ describe('v8debugapi', function() {
         });
       });
 
-    it('should special-case line 1 to handle Node.js module wrapping',
-      function(done) {
-        var bp1 = { id: 'bp1', location: {path: __filename, line: 1}};
-        api.set(bp1, function(err) {
-          assert.ifError(err);
-          assert(bp1.location.column, 'a column should have been added');
-          assert(bp1.location.column ===
-                 require('module').wrap('something').indexOf('something'));
-          api.clear(bp1);
-          done();
-        });
-      });
 
     it('should correctly stop on line-1 breakpoints', function(done) {
       var foo = require('./fixtures/foo.js');


### PR DESCRIPTION
The API rejects breakpoint updates if sees any unknown property on the
breakpoint object. It is not okay to add additional properties on breakpoint.

@matthewloring PTAL.