### PR TITLE
Added source map support for babel

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,4 +1,4 @@
 node_modules
 test/e2e/node_modules
-test/fixtures/coffee
+test/fixtures
 coverage

--- a/lib/v8debugapi.js
+++ b/lib/v8debugapi.js
@@ -331,6 +331,14 @@ module.exports.create = function(logger_, config_, fileStats_) {
               uncompiled + ' <<', err);
           }
         };
+      case 'es6':
+      case 'es':
+      case 'jsx':
+        return function(uncompiled) {
+          // If we want to support es6 watch expressions we can compile them here.
+          // Babel is a large dependency to have if we don't need it in all cases.
+          return uncompiled;
+        };
     }
     return null;
   }

--- a/test/fixtures/es6/transpile.es6
+++ b/test/fixtures/es6/transpile.es6
@@ -1,0 +1,22 @@
+var i = 1;
+var foo = (j) => {
+  return i + j + `hi`;
+}
+
+module.exports.foo = foo
+
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/test/fixtures/es6/transpile.js
+++ b/test/fixtures/es6/transpile.js
@@ -1,0 +1,23 @@
+"use strict";
+var i = 1;
+var foo = function foo(j) {
+  return i + j + "hi";
+};
+
+module.exports.foo = foo;
+
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/test/fixtures/es6/transpile.js.map
+++ b/test/fixtures/es6/transpile.js.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "file": "transpile.js",
+  "sourceRoot": "",
+  "sources": [
+    "transpile.es6"
+  ],
+  "names": [],
+  "mappings": ";;AAAA,IAAI,CAAC,GAAG,CAAC,CAAC;AACV,IAAI,GAAG,GAAG,SAAN,GAAG,CAAI,CAAC,EAAK;AACf,SAAO,EAAE,CAAC,GAAG,CAAC,OAAO,CAAC;CACvB,CAAA;;AAED,MAAM,CAAC,OAAO,CAAC,GAAG,GAAG,GAAG,CAAA",
+  "sourcesContent": [ "var i = 0;\nvar foo = (j) => {\n  return ++i + j + `hi`;\n}\n\nmodule.exports.foo = foo\n\n/**\n * Copyright 2015 Google Inc. All Rights Reserved.\n *\n * Licensed under the Apache License, Version 2.0 (the \"License\");\n * you may not use this file except in compliance with the License.\n * You may obtain a copy of the License at\n *\n *      http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required by applicable law or agreed to in writing, software\n * distributed under the License is distributed on an \"AS IS\" BASIS,\n * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n * See the License for the specific language governing permissions and\n * limitations under the License.\n */\n" ]
+}

--- a/test/test-v8debugapi.js
+++ b/test/test-v8debugapi.js
@@ -352,7 +352,7 @@ describe('v8debugapi', function() {
 
     });
 
-    it('should be possible to set conditional breakpoints in compiled code',
+    it('should be possible to set conditional breakpoints in coffeescript',
       function (done) {
         var bp = {
           id: 'coffee-id-1729',
@@ -378,7 +378,33 @@ describe('v8debugapi', function() {
         });
     });
 
-    it('should be possible to view watch expressions in compiled code',
+    it('should be possible to set conditional breakpoints with babel',
+      function (done) {
+        var bp = {
+          id: 'babel-id-1729',
+          location: { path: './test/fixtures/es6/transpile.es6',
+            line: 3 },
+          condition: 'i + j === 3'
+        };
+        var tt = require('./fixtures/es6/transpile');
+        api.set(bp, function(err) {
+          assert.ifError(err);
+          api.wait(bp, function(err) {
+            assert.ifError(err);
+            assert.ok(bp.stackFrames);
+
+            var topFrame = bp.stackFrames[0];
+            assert.equal(topFrame['function'], 'foo');
+            assert.equal(topFrame.arguments[0].name, 'j');
+            assert.equal(topFrame.arguments[0].value, '2');
+            api.clear(bp);
+            done();
+          });
+          process.nextTick(function() {tt.foo(1); tt.foo(2);});
+        });
+    });
+
+    it('should be possible to view watch expressions in coffeescript',
       function(done) {
         var bp = {
             id: 'coffee-id-1729',
@@ -407,7 +433,7 @@ describe('v8debugapi', function() {
         });
     });
 
-    it('should capture without values for invalid watch expressions in compiled code',
+    it('should capture without values for invalid watch expressions in coffeescript',
       function(done) {
         var bp = {
             id: 'coffee-id-1729',


### PR DESCRIPTION
For now, we disallow babel pre-compiled files with the js extension
because we have no other way to differentiate pre and post compiled
files. Supported extensions are es6, es, jsx.