### PR TITLE
fix reporting of file not found error

### DIFF
--- a/lib/debuglet.js
+++ b/lib/debuglet.js
@@ -313,7 +313,7 @@ Debuglet.prototype.addBreakpoint_ = function(breakpoint, cb) {
 
   that.v8debug_.set(breakpoint, function(err) {
     if (err) {
-      cb(message);
+      cb(err);
       return;
     }
 


### PR DESCRIPTION
The callback was getting called with the wrong value resulting the breakpoint
never being updated w/ the error on the server side. This causes the client to
wait upon a breakpoint forever even though we didn't even set the breakpoint in
the debuglet.