### PR TITLE
Heuristic for resolving ambiguous file paths

### DIFF
--- a/config.js
+++ b/config.js
@@ -20,6 +20,11 @@ module.exports = {
   enabled: true,
   workingDirectory: process.cwd(),
 
+  // The path within your repository to the directory containing the
+  // package.json for your deployed application. This should be provided
+  // if your deployed application appears as a subdirectory of your repository.
+  appPathRelativeToRepository: undefined,
+
   // Log levels: 0-disabled,1-error,2-warn,3-info,4-debug.
   logLevel: 1,
 

--- a/index.js
+++ b/index.js
@@ -31,6 +31,10 @@ if (process.env.hasOwnProperty('GCLOUD_DEBUG_LOGLEVEL')) {
 if (process.env.hasOwnProperty('GCLOUD_DEBUG_DISABLE')) {
   config.enabled = false;
 }
+if (process.env.hasOwnProperty('GCLOUD_DEBUG_REPO_APP_PATH')) {
+  config.appPathRelativeToRepository =
+    process.env.GCLOUD_DEBUG_REPO_APP_PATH;
+}
 
 if (config.enabled) {
   var debuglet = new Debuglet(

--- a/lib/v8debugapi.js
+++ b/lib/v8debugapi.js
@@ -384,10 +384,26 @@ module.exports.create = function(logger_, config_, fileStats_) {
   // }
 
   function findScripts(scriptPath) {
+    // Use repository relative mapping if present.
+    if (config.appPathRelativeToRepository) {
+      var candidate = scriptPath.replace(config.appPathRelativeToRepository,
+        config.workingDirectory);
+      // There should be no ambiguity resolution if project root is provided.
+      return fileStats[candidate] ? [ candidate ] : [];
+    }
     var regexp = pathToRegExp(scriptPath);
-    var matches = Object.keys(fileStats).filter(function(script) {
-      return regexp.test(script);
-    });
+    // Next try to match path.
+    var matches = Object.keys(fileStats).filter(regexp.test.bind(regexp));
+    // Finally look for files with the same name regardless of path.
+    if (matches.length !== 1) {
+      matches = Object.keys(fileStats);
+      var components = scriptPath.split(path.sep);
+      for (var i = components.length - 1;
+           i >= 0 && matches.length > 1; i--) {
+        regexp = pathToRegExp(components.slice(i).join(path.sep));
+        matches = matches.filter(regexp.test.bind(regexp));
+      }
+    }
     return matches;
   }
 

--- a/test/standalone/test-env-relative-repository-path.js
+++ b/test/standalone/test-env-relative-repository-path.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+process.env.GCLOUD_PROJECT_NUM = 0;
+process.env.GCLOUD_DEBUG_REPO_APP_PATH = '/my/project/root';
+
+var assert = require('assert');
+var agent = require('../..');
+var api;
+
+describe('repository relative paths', function() {
+
+  before(function(done) {
+    setTimeout(function() {
+      // Wait for v8deub api to initialize.
+      api = agent.private_.v8debug_;
+      done();
+    }, 100);
+  });
+
+  after(function() {
+    assert.equal(api.numBreakpoints_(), 0,
+      'there should be no breakpoints active');
+    assert.equal(api.numListeners_(), 0,
+      'there should be no listeners active');
+  });
+
+  it('should correctly substitute when provided', function(done) {
+    var bp = {
+      id: 0,
+      location: {
+        line: 1,
+        path: '/my/project/root/test/fixtures/a/hello.js'
+      }
+    };
+    api.set(bp, function(err) {
+      assert.ifError(err);
+      api.clear(bp);
+      done();
+    });
+  });
+
+});

--- a/test/test-v8debugapi.js
+++ b/test/test-v8debugapi.js
@@ -80,6 +80,28 @@ describe('v8debugapi', function() {
       });
     });
 
+  it('should disambiguate incorrect path if filename is unique',
+    function(done) {
+      require('./fixtures/foo.js');
+      var bp = { id: 0, location: {line: 1, path: '/test/foo.js'}};
+      api.set(bp, function(err) {
+        assert.ifError(err);
+        api.clear(bp);
+        done();
+      });
+    });
+
+  it('should disambiguate incorrect path if partial path is unique',
+    function(done) {
+      require('./fixtures/foo.js');
+      // hello.js is not unique but a/hello.js is.
+      var bp = { id: 0, location: {line: 1, path: '/Server/a/hello.js'}};
+      api.set(bp, function(err) {
+        assert.ifError(err);
+        api.clear(bp);
+        done();
+      });
+    });
 
   describe('invalid breakpoints', function() {
     var badBreakpoints = [


### PR DESCRIPTION
This heuristic will correctly find scripts if their name is unique in
the executing project regardless of path to handle the case where the
app was deployed to a different path than that used in development.

Progress on #51