### PR TITLE
fix the script path we use to set the v8 bp

### DIFF
--- a/lib/v8debugapi.js
+++ b/lib/v8debugapi.js
@@ -286,7 +286,7 @@ module.exports.create = function(logger_, config_, fileStats_) {
       column += MODULE_WRAP_PREFIX_LENGTH - 1;
     }
 
-    var v8bp = setByRegExp(scriptPath, line, column);
+    var v8bp = setByRegExp(matchingScript, line, column);
     if (!v8bp) {
       return setErrorStatusAndCallback(cb, breakpoint,
         StatusMessage.BREAKPOINT_SOURCE_LOCATION,


### PR DESCRIPTION
We were using the original path provided by the Debug API rather than the app
local path we computed based on the file-matching heuristics.

@matthewloring PTAL.