### PR TITLE
Update dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
   "devDependencies": {
     "closure-npc": "*",
     "coveralls": "^2.11.2",
-    "istanbul": "^0.3.17",
+    "istanbul": "^0.4.1",
     "jshint": "^2.7.0",
     "mocha": "^2.2.4",
-    "nock": "^2.13.0",
+    "nock": "^3.6.0",
     "proxyquire": "^1.4.0"
   },
   "dependencies": {


### PR DESCRIPTION
I was playing around with snyk and found
https://snyk.io/vuln/npm:uglify-js:20151024. We depend on uglify
through istanbul (dev only) so it shouldn't matter but
updating is always good as are green badges.