### PR TITLE
Unify warnings for using node v5.2 and <v0.12 through debugger ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 npm-debug.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This module provides Cloud Debug support for Node.js applications. [Google Cloud
 [![Cloud Debugger Intro](http://img.youtube.com/vi/tyHcK_kAOpw/0.jpg)](https://www.youtube.com/watch?v=tyHcK_kAOpw)
 
 ## Prerequisites
-* Your application will need to be using Node.js version 0.12 or greater. Node.js v5+ is recommended.
+* Your application will need to be using Node.js version 0.12 or greater. Node.js v5+ is recommended. (Node.js v5.2.0 is not supported on account of [this bug](https://github.com/nodejs/node/issues/4297))
 * The source of your application is uploaded to a [cloud source repository](https://cloud.google.com/tools/cloud-repositories/docs/). The Debugger UI needs the source to be available in order to set breakpoints.
 
 ## Quick Start (Node.js v4.x+)

--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@
 var config = require('./config.js');
 var logger = require('@google/cloud-diagnostics-common').logger;
 var Debuglet = require('./lib/debuglet.js');
-var semver = require('semver');
 
 // exports is populated by the agent
 module.exports = {};
@@ -38,11 +37,6 @@ if (process.env.hasOwnProperty('GCLOUD_DEBUG_REPO_APP_PATH')) {
 }
 
 var log = logger.create(config.logLevel, '@google/cloud-debug');
-
-if (semver.satisfies(process.version, '5.2')) {
-  log.error('Debug is not supported on Node v5.2');
-  return;
-}
 
 if (config.enabled) {
   var debuglet = new Debuglet(config, log);

--- a/lib/debuglet.js
+++ b/lib/debuglet.js
@@ -18,8 +18,9 @@
 
 var fs = require('fs');
 var path = require('path');
-var EventEmitter = require('events');
+var EventEmitter = require('events').EventEmitter;
 var util = require('util');
+var semver = require('semver');
 
 var v8debugapi = require('./v8debugapi.js');
 var DebugletApi = require('./debugletapi.js');
@@ -30,9 +31,8 @@ var StatusMessage = require('./apiclasses.js').StatusMessage;
 
 var assert = require('assert');
 
-var NODE_VERSION_MESSAGE = 'V8 Debug API not available – make sure you are ' +
-    'running Node.js >=0.12. Cloud Debugger agent will not be able to take ' +
-    'snapshots.';
+var NODE_VERSION_MESSAGE = 'Node.js version not supported. Node.js 5.2.0 and ' +
+  ' versions older than 0.12 are not supported.';
 
 module.exports = Debuglet;
 
@@ -110,11 +110,11 @@ Debuglet.prototype.start = function() {
           return;
         }
 
-        if (!that.v8debug_) {
-          // V8 Debug API is missing. We report an error message about the Node.js
-          // version, but we keep on running. The idea is that the user may miss
-          // the error message on the console. This way we can report the error
-          // when the user tries to set a breakpoint.
+        if (semver.satisfies(process.version, '5.2 || <0.12')) {
+          // Using an unsupported version. We report an error message about the
+          // Node.js version, but we keep on running. The idea is that the user
+          // may miss the error message on the console. This way we can report the
+          // error when the user tries to set a breakpoint.
           that.logger_.error(NODE_VERSION_MESSAGE);
         }
 
@@ -299,17 +299,15 @@ Debuglet.prototype.removeBreakpoint_ = function(breakpoint) {
  */
 Debuglet.prototype.addBreakpoint_ = function(breakpoint, cb) {
   var that = this;
-  var message;
 
-  if (!that.v8debug_) {
-    message = NODE_VERSION_MESSAGE;
+  if (semver.satisfies(process.version, '5.2 || <0.12')) {
+    var message = NODE_VERSION_MESSAGE;
     that.logger_.error(message);
     breakpoint.status = new StatusMessage(StatusMessage.UNSPECIFIED,
       message, true);
     setImmediate(function() { cb(message); });
     return;
   }
-
 
   that.v8debug_.set(breakpoint, function(err) {
     if (err) {

--- a/test/e2e/test-error-message.js
+++ b/test/e2e/test-error-message.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var assert = require('assert');
+var request = require('request');
+var logger = require('@google/cloud-diagnostics-common').logger;
+var config = require('../../config.js');
+var Debuglet = require('../../lib/debuglet.js');
+var semver = require('semver');
+
+var nock = require('nock');
+nock.disableNetConnect();
+
+describe(__filename, function() {
+  it('should re-fetch breakpoints on error', function(done) {
+    assert(semver.satisfies(process.version, '5.2.x'));
+    var debuglet = new Debuglet(
+      config, logger.create(config.logLevel, '@google/cloud-debug'));
+
+    process.env.GCLOUD_PROJECT_NUM=0;
+
+    var API = 'https://clouddebugger.googleapis.com';
+
+    var scope = nock(API)
+      .post('/v2/controller/debuggees/register')
+      .reply(200, {
+        debuggee: {
+          id: 'bar'
+        }
+      })
+      .get('/v2/controller/debuggees/bar/breakpoints')
+      .reply(200, {
+        breakpoints: [{
+          id: 'test',
+          location: { path: 'fixtures/foo.js', line: 2 }
+        }]
+      })
+      .put('/v2/controller/debuggees/bar/breakpoints/test', function(body) {
+        var status = body.breakpoint.status;
+        var partialMessage = 'Node.js version not supported.';
+        return status.isError &&
+          (status.description.format.indexOf(partialMessage) !== -1);
+      })
+      .reply(200);
+
+    debuglet.once('started', function() {
+      debuglet.debugletApi_.request_ = request; // Avoid authing.
+    });
+    debuglet.once('registered', function reg(id) {
+      assert(id === 'bar');
+      setTimeout(function() {
+        debuglet.stop();
+        scope.done();
+        done();
+      }, 200);
+    });
+
+    debuglet.start();
+  });
+});


### PR DESCRIPTION
The agent is currently crashing on node 0.10 because
EventEmitter.prototype is undefined which breaks inheritance for the
debuglet. This patch causes the agent to shutdown immediately if running
on an unsupported version of node. It also addresses #7 since the
version check runs first and it is now easier to reason about graceful
exit in this case.