### PR TITLE
Expand testing for invalid watch expressions

### DIFF
--- a/test/test-v8debugapi.js
+++ b/test/test-v8debugapi.js
@@ -340,7 +340,7 @@ describe('v8debugapi', function() {
       var bp  = {
         id: breakpointInFoo.id,
         location: breakpointInFoo.location,
-        expressions: [':)', 'process()', 'process=this']
+        expressions: [':)', 'process()', 'process=this', 'i', 'process._not._def']
       };
       api.set(bp, function(err) {
         assert.ifError(err);


### PR DESCRIPTION
Additional cases:
 - undeclared variable names
 - dereferencing undefined

Fixes #13