### PR TITLE
Regression test for #56 on GH

### DIFF
--- a/test/fixtures/a/hello.js
+++ b/test/fixtures/a/hello.js
@@ -1,2 +1,4 @@
 'use strict';
-module.exports.hello = function() { console.log('hello world from a'); };
+module.exports.hello = function() {
+  console.log('hello world from a');
+};

--- a/test/standalone/test-env-relative-repository-path.js
+++ b/test/standalone/test-env-relative-repository-path.js
@@ -22,6 +22,7 @@ process.env.GCLOUD_DEBUG_REPO_APP_PATH = '/my/project/root';
 var assert = require('assert');
 var agent = require('../..');
 var api;
+var h = require('../fixtures/a/hello.js');
 
 describe('repository relative paths', function() {
 
@@ -44,14 +45,18 @@ describe('repository relative paths', function() {
     var bp = {
       id: 0,
       location: {
-        line: 1,
+        line: 3,
         path: '/my/project/root/test/fixtures/a/hello.js'
       }
     };
     api.set(bp, function(err) {
       assert.ifError(err);
-      api.clear(bp);
-      done();
+      api.wait(bp, function(err) {
+        assert.ifError(err);
+        api.clear(bp);
+        done();
+      });
+      process.nextTick(function() { h.hello(); });
     });
   });
 


### PR DESCRIPTION
When testing relative repository paths, we need to ensure that the set
breakpoint is hit when the script executes since v8 will accept
breakpoints in scripts that are not yet loaded masking an error in
selecting the correct script.

Fixes #56