### PR TITLE
Only mark breakpoints done when api call succeeds

### DIFF
--- a/lib/debuglet.js
+++ b/lib/debuglet.js
@@ -339,19 +339,16 @@ Debuglet.prototype.completeBreakpoint_ = function(breakpoint) {
   var that = this;
 
   that.logger_.info('\tupdating breakpoint data on server', breakpoint.id);
-  // TODO: in case of transient errors, retry the update operation
-  // Put in the completed breakpoints map only when the update successfully
-  // completes. Otherwise - we refuse to set the breakpoint, but the server
-  // has never seen the update.
   that.debugletApi_.updateBreakpoint(breakpoint, function(err/*, body*/) {
     if (err) {
       that.logger_.error('Unable to complete breakpoint on server', err);
+    } else {
+      // TODO(ofrobots): breakpoint may be holding on to a lot of data. We only
+      // need to remember the breakpoint id.
+      that.completedBreakpointMap_[breakpoint.id] = breakpoint;
+      that.removeBreakpoint_(breakpoint);
     }
   });
-  // TODO(ofrobots): breakpoint may be holding on to a lot of data. We only
-  // need to remember the breakpoint id.
-  that.completedBreakpointMap_[breakpoint.id] = breakpoint;
-  that.removeBreakpoint_(breakpoint);
 };
 
 


### PR DESCRIPTION
The first part of the TODO is deemed no longer necessary because we
already have our request handle retriest for transient errors.