### PR TITLE
Remove TODO to use v8 as parser

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -52,8 +52,6 @@ function evaluate(expression, frame) {
   }
 
   // Now actually ask V8 to evaluate the expression
-  // TODO: it would be really nice if V8 gave us an API for this
-  // so that we don't have to include an external parser
   try {
     var mirror = frame.evaluate(expression);
     return {


### PR DESCRIPTION
It seems that this has been asked for in the past and the V8 team
justified why they do not want these apis to be exposed. See Andreas
Rossberg's answer here:
https://groups.google.com/forum/#!topic/v8-users/_WracRX9BTQ