### PR TITLE
Display error for native properties

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -26,6 +26,10 @@ var semver = require('semver');
 
 var StatusMessage = require('./apiclasses.js').StatusMessage;
 
+var BUFFER_FULL_MESSAGE_INDEX = 0;
+var NATIVE_PROPERTY_MESSAGE_INDEX = 1;
+var GETTER_MESSAGE_INDEX = 2;
+
 // TODO: document this file
 
 // returns an object with three fields: stacksframes,
@@ -79,13 +83,17 @@ function StateResolver(execState, expressions, config) {
   this.evaluatedExpressions_ = [];
   this.totalSize_ = 0;
 
-  // The 0-th object in the variable table is a sentinel 'buffer full' error
-  // message value
-  this.rawVariableTable_ = [ null ];
-  this.resolvedVariableTable_ = [
+  this.rawVariableTable_ = [ null, null, null ];
+  this.resolvedVariableTable_ = [];
+  this.resolvedVariableTable_[BUFFER_FULL_MESSAGE_INDEX] =
     { status: new StatusMessage(StatusMessage.VARIABLE_VALUE,
-                                'Buffer full', true) }
-  ];
+                                'Max data size reached', true) };
+  this.resolvedVariableTable_[NATIVE_PROPERTY_MESSAGE_INDEX] =
+    { status: new StatusMessage(StatusMessage.VARIABLE_VALUE,
+                                'Native properties are not available', true) };
+  this.resolvedVariableTable_[GETTER_MESSAGE_INDEX] =
+    { status: new StatusMessage(StatusMessage.VARIABLE_VALUE,
+                                'Properties with getters are not available', true) };
 }
 
 
@@ -114,7 +122,7 @@ StateResolver.prototype.capture = function() {
   }
 
   // Now resolve the variables
-  var index = 1; // skip the sentinel value
+  var index = 3; // skip the sentinel values
   while (index < that.rawVariableTable_.length && // NOTE: length changes in loop
          that.totalSize_ < that.config_.capture.maxDataSize) {
     assert(!that.resolvedVariableTable_[index]); // shouldn't have it resolved yet
@@ -145,7 +153,7 @@ StateResolver.prototype.trimVariableTable_ = function(fromIndex, frames) {
     variables.forEach(function (variable) {
       if (variable.varTableIndex && variable.varTableIndex >= fromIndex) {
         // make it point to the sentinel 'buffer full' value
-        variable.varTableIndex = 0;
+        variable.varTableIndex = BUFFER_FULL_MESSAGE_INDEX;
       }
       if (variable.members) {
         processBufferFull(variable.members);
@@ -365,7 +373,7 @@ StateResolver.prototype.resolveMirrorSlow_ = function(mirror) {
     keys = keys.slice(0, that.config_.capture.maxProperties);
   }
   var members = keys.map(function(prop) {
-    return that.resolveVariable_(prop, mirror.property(prop).value());
+    return that.resolveMirrorProperty_(mirror.property(prop));
   });
 
   return {
@@ -386,11 +394,23 @@ StateResolver.prototype.resolveMirrorFast_ = function(mirror) {
   };
 };
 StateResolver.prototype.getMirrorProperties_ = function(mirror) {
-  var numProperties = this.config_.capture.maxProperties || 1000;
+  var numProperties = this.config_.capture.maxProperties;
   var namedProperties = mirror.properties(1, numProperties);
   var indexedProperties = mirror.properties(2, numProperties);
   return namedProperties.concat(indexedProperties);
 };
 StateResolver.prototype.resolveMirrorProperty_ = function(property) {
+  if (property.isNative()) {
+    return {
+      name: property.name(),
+      varTableIndex: NATIVE_PROPERTY_MESSAGE_INDEX
+    };
+  }
+  if (property.hasGetter()) {
+    return {
+      name: property.name(),
+      varTableIndex: GETTER_MESSAGE_INDEX
+    };
+  }
   return this.resolveVariable_(property.name(), property.value());
 };


### PR DESCRIPTION
This prevents native properties from being reported as undefined when we
are unable to check their values for fear of executing stateful code.