### PR TITLE
defer breakpoint callback

### DIFF
--- a/lib/v8debugapi.js
+++ b/lib/v8debugapi.js
@@ -196,7 +196,12 @@ module.exports.create = function(logger_, config_, fileStats_) {
       var listener = onBreakpointHit.bind(
           null, breakpoint, function(err) {
             delete listeners[num];
-            callback(err);
+            // This method is called from the debug event listener, which
+            // swallows all exception. We defer the callback to make sure the
+            // user errors aren't silenced.
+            setImmediate(function() {
+              callback(err);
+            });
           });
 
       listeners[num] = listener;


### PR DESCRIPTION
Make sure the breakpoint hit callback isn't called back from the debug
listener, which swallows user exceptions thrown from the callback.

@matthewloring PTAL.