### PR TITLE
Ensure breakpoint variable's names are strings

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -442,17 +442,18 @@ StateResolver.prototype.getMirrorProperties_ = function(mirror) {
 };
 
 StateResolver.prototype.resolveMirrorProperty_ = function(property) {
+  var name = String(property.name);
   if (property.isNative()) {
     return {
-      name: property.name(),
+      name: name,
       varTableIndex: NATIVE_PROPERTY_MESSAGE_INDEX
     };
   }
   if (property.hasGetter()) {
     return {
-      name: property.name(),
+      name: name,
       varTableIndex: GETTER_MESSAGE_INDEX
     };
   }
-  return this.resolveVariable_(property.name(), property.value());
+  return this.resolveVariable_(name, property.value());
 };

--- a/lib/state.js
+++ b/lib/state.js
@@ -442,7 +442,7 @@ StateResolver.prototype.getMirrorProperties_ = function(mirror) {
 };
 
 StateResolver.prototype.resolveMirrorProperty_ = function(property) {
-  var name = String(property.name);
+  var name = String(property.name());
   if (property.isNative()) {
     return {
       name: name,

--- a/test/test-v8debugapi.js
+++ b/test/test-v8debugapi.js
@@ -456,6 +456,16 @@ describe('v8debugapi', function() {
           assert.equal(watch.name, 'process');
           assert.ok(watch.varTableIndex);
 
+          // Make sure the process object looks sensible.
+          var processVal = bp.variableTable[watch.varTableIndex];
+          assert.ok(processVal);
+          assert.ok(processVal.members.some(function(m) {
+            return m.name === 'nextTick' && m.value.indexOf('function') === 0;
+          }));
+          assert.ok(processVal.members.some(function(m) {
+            return m.name === 'versions' && m.varTableIndex;
+          }));
+
           api.clear(bp);
           done();
         });


### PR DESCRIPTION
In Node.js 4+, property mirror's names can be numbers in the case of array indices. This caused the controller API to reject breakpoint update messages we sent.

Fixes: #96.