### PR TITLE
Report unique ids when not on GCP

### DIFF
--- a/lib/debuglet.js
+++ b/lib/debuglet.js
@@ -95,7 +95,7 @@ Debuglet.prototype.start = function() {
     if (process.env.GAE_MINOR_VERSION) {
       id = 'GAE-' + process.env.GAE_MINOR_VERSION;
     }
-    scanner.scan(!!id, that.config_.workingDirectory,
+    scanner.scan(!id, that.config_.workingDirectory,
         function(err, fileStats, hash) {
       if (err) {
         that.logger_.error('Error scanning the filesystem.', err);

--- a/test/e2e/test.js
+++ b/test/e2e/test.js
@@ -60,6 +60,7 @@ module.exports.runTest = function runTest() {
     var debuglet = agent.private_;
     assert.ok(debuglet.debugletApi_, 'debuglet api is active');
     var api = debuglet.debugletApi_;
+    assert.ok(api.uid_, 'debuglet provided unique id');
     assert.ok(api.debuggeeId_, 'debuglet has registered');
 
     var debuggee = api.debuggeeId_;
@@ -194,6 +195,8 @@ module.exports.runTest = function runTest() {
         console.error(e);
       });
     });
+  }).catch(function(e) {
+    console.error(e);
   });
 };
 


### PR DESCRIPTION
Previously, the debuglet would report a unique id of `undefined` which is not unique.