### PR TITLE
Attempt to fix travis encrypted keyfiles

### DIFF
--- a/test/e2e/test.js
+++ b/test/e2e/test.js
@@ -215,6 +215,10 @@ if (cluster.isMaster) {
   }
   runTest();
 } else {
+  if (process.env.TRAVIS_SECURE_ENV_VARS) {
+    process.env.GOOGLE_APPLICATION_CREDENTIALS =
+      'node-team-debug-test-a03aecc1d97a.json';
+  }
   var agent = require('../..');
   setTimeout(process.send.bind(process, agent), 7000);
   setInterval(fib.bind(null, 12), 2000);


### PR DESCRIPTION
This problem only manifests when testing master so it cannot be checked
with pull requests. It appears that the cluster module is interfering
with travis' file decryption and I believe this change will help.