### PR TITLE
Correct log formatting for non-primitives

### DIFF
--- a/lib/debuglet.js
+++ b/lib/debuglet.js
@@ -343,9 +343,7 @@ Debuglet.prototype.addBreakpoint_ = function(breakpoint, cb) {
       that.logger_.info('Breakpoint hit!: ' + breakpoint.id);
       if (breakpoint.action === 'LOG') {
         var message = Debuglet.format(breakpoint.logMessageFormat,
-          breakpoint.evaluatedExpressions.map(function(v) {
-            return v.value;
-          }));
+          breakpoint.evaluatedExpressions.map(JSON.stringify));
         console.log(message);
         if (!that.completedBreakpointMap_[breakpoint.id]) {
           setTimeout(function() {

--- a/lib/v8debugapi.js
+++ b/lib/v8debugapi.js
@@ -23,7 +23,6 @@
 /** @const */ var state = require('./state.js');
 /** @const */ var logModule = require('@google/cloud-diagnostics-common').logger;
 /** @const */ var apiclasses = require('./apiclasses.js');
-/** @const */ var _ = require('lodash');
 /** @const */ var StatusMessage = apiclasses.StatusMessage;
 
 /** @const */ var messages = {
@@ -485,18 +484,22 @@ module.exports.create = function(logger_, config_, fileStats_) {
         }
       }
     }
-    var localConfig;
     if (breakpoint.action === 'LOG') {
-      localConfig = { capture: { maxFrames: 0 } };
-      _.defaultsDeep(localConfig, config);
+      // TODO: This doesn't work with compiled languages if there is an error
+      // compiling one of the expressions in the loop above.
+      var frame = execState.frame(0);
+      var evaluatedExpressions = breakpoint.expressions.map(function(exp) {
+        var result = state.evaluate(exp, frame);
+        return result.error ? result.error : result.mirror.value();
+      });
+      breakpoint.evaluatedExpressions = evaluatedExpressions;
     } else {
-      localConfig = config;
+      var captured = state.capture(execState, breakpoint.expressions, config);
+      breakpoint.stackFrames = captured.stackFrames;
+      breakpoint.variableTable = captured.variableTable;
+      breakpoint.evaluatedExpressions =
+        expressionErrors.concat(captured.evaluatedExpressions);
     }
-    var captured = state.capture(execState, breakpoint.expressions, localConfig);
-    breakpoint.stackFrames = captured.stackFrames;
-    breakpoint.variableTable = captured.variableTable;
-    breakpoint.evaluatedExpressions =
-      expressionErrors.concat(captured.evaluatedExpressions);
   }
 
   /**

--- a/test/e2e/test.js
+++ b/test/e2e/test.js
@@ -1,8 +1,8 @@
 /* KEEP THIS CODE AT THE TOP SO THAT THE BREAKPOINT LINE NUMBERS DON'T CHANGE */
 'use strict';
 function fib(n) {
-  if (n < 2) { return n; }
-  return fib(n - 1) + fib(n - 2);
+  if (n < 2) { return n; } var o = { a: [1, 'hi', true] };
+  return fib(n - 1, o) + fib(n - 2, o); // adding o to appease linter.
 }
 /**
  * Copyright 2015 Google Inc. All Rights Reserved.
@@ -140,8 +140,8 @@ function runTest() {
           location: {path: 'test.js', line: 5},
           condition: 'n === 10',
           action: 'LOG',
-          expressions: ['n'],
-          log_message_format: 'n is: $0'
+          expressions: ['o'],
+          log_message_format: 'o is: $0'
         });
         // I don't know what I am doing. There is a better way to write the
         // following using promises.
@@ -167,7 +167,7 @@ function runTest() {
         return Q.delay(10 * 1000).then(function() { return result; });
       })
       .then(function(result) {
-        assert(transcript.indexOf('n is: 10') !== -1);
+        assert(transcript.indexOf('o is: {"a":[1,"hi",true]}') !== -1);
         deleteBreakpoint(result.debuggee, result.breakpoint).then();
         return result.debuggee;
       })
@@ -225,7 +225,7 @@ function runTest() {
         assert.ok(arg, 'should find the n argument');
         assert.strictEqual(arg.value, '10');
         console.log('-- checking log point was hit again');
-        assert.ok(transcript.split('n is: 10').length > 4);
+        assert.ok(transcript.split('o is: {"a":[1,"hi",true]}').length > 4);
         console.log('Test passed');
         process.exit(0);
       })


### PR DESCRIPTION
We were not correctly resolving non-primitive types for log points. This
change prevents a full capture from occuring and gives correct logs for
objects and arrays.