### PR TITLE
Fixes crash if gcloud project isn't identified

### DIFF
--- a/lib/debuglet.js
+++ b/lib/debuglet.js
@@ -88,7 +88,7 @@ Debuglet.prototype.start = function() {
   fs.stat(path.join(that.config_.workingDirectory, 'package.json'), function(err) {
     if (err && err.code === 'ENOENT') {
       that.logger_.error('No package.json located in working directory.');
-      that.emit('error', new Error('No package.json found.'));
+      that.emit('initError', new Error('No package.json found.'));
       return;
     }
     var id;
@@ -99,7 +99,7 @@ Debuglet.prototype.start = function() {
         function(err, fileStats, hash) {
       if (err) {
         that.logger_.error('Error scanning the filesystem.', err);
-        that.emit('error', err);
+        that.emit('initError', err);
         return;
       }
       that.v8debug_ = v8debugapi.create(that.logger_, that.config_, fileStats);
@@ -112,7 +112,7 @@ Debuglet.prototype.start = function() {
         if (err) {
           that.logger_.error('Unable to initialize the debuglet api' +
             ' -- disabling debuglet', err);
-          that.emit('error', err);
+          that.emit('initError', err);
           return;
         }
 

--- a/test/standalone/test-debuglet.js
+++ b/test/standalone/test-debuglet.js
@@ -61,7 +61,7 @@ describe(__filename, function(){
       .get('/computeMetadata/v1/project/numeric-project-id')
       .reply(404);
 
-    debuglet.once('error', function(err) {
+    debuglet.once('initError', function(err) {
       assert(err);
       scope.done();
       done();
@@ -69,6 +69,22 @@ describe(__filename, function(){
     debuglet.once('started', function() {
       assert.fail();
     });
+    debuglet.start();
+  });
+
+  it('should not crash without project num', function(done) {
+    delete process.env.GCLOUD_PROJECT;
+    var scope = nock('http://metadata.google.internal')
+      .get('/computeMetadata/v1/project/numeric-project-id')
+      .reply(404);
+
+    debuglet.once('started', function() {
+      assert.fail();
+    });
+    setTimeout(function() {
+      scope.done();
+      done();
+    }, 1500);
     debuglet.start();
   });
 


### PR DESCRIPTION
The debuglet currently emits events for testing purposes. When not
handled outside of a testing environment, error events were causing
crashes where warning and turning off the debugger is preferred.

Fixes #126