### PR TITLE
Allow ES6 conditions and watches

### DIFF
--- a/lib/v8debugapi.js
+++ b/lib/v8debugapi.js
@@ -239,7 +239,15 @@ module.exports.create = function(logger_, config_, fileStats_) {
     if (breakpoint.condition) {
       var acorn = require('acorn');
       try {
-        ast = acorn.parse(breakpoint.condition, { sourceType: 'script'});
+        // We parse as ES6; even though the underlying V8 version may only
+        // support a subset. This should be fine as the objective of the parse
+        // is to heuristically find side-effects. V8 will raise errors later
+        // if the syntax is invalid. It would have been nice if V8 had made the
+        // parser API available us :(.
+        ast = acorn.parse(breakpoint.condition, {
+          sourceType: 'script',
+          ecmaVersion: 6
+        });
         var validator = require('./validator.js');
         if (!validator.isValid(ast)) {
           return setErrorStatusAndCallback(cb, breakpoint,
@@ -588,6 +596,3 @@ module.exports.create = function(logger_, config_, fileStats_) {
 
   return singleton;
 };
-
-
-

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -87,6 +87,16 @@ function isValid(node) {
     case 'UnaryExpression':
       return isValid(node.argument);
 
+    case 'SpreadElement':
+      return isValid(node.argument);
+
+    case 'TemplateLiteral':
+      return node.quasis.every(isValid) && node.expressions.every(isValid);
+    case 'TaggedTemplateExpression':
+      return isValid(node.tag) && isValid(node.quasi);
+    case 'TemplateElement':
+      return true;
+
     default:
       return false;
   }

--- a/test/test-v8debugapi.js
+++ b/test/test-v8debugapi.js
@@ -303,7 +303,9 @@ describe('v8debugapi', function() {
     '!fib()',
     '1+fib()',
     'x++',
-    '[1, 2, 3, 4, x = 1, x == 1, x === 1]'
+    '[1, 2, 3, 4, x = 1, x == 1, x === 1]',
+    '[0].values()',
+    'new Object()',
   ]);
   conditionTests('valid conditions', function(err) { assert.ifError(err); }, [
     null,
@@ -319,8 +321,38 @@ describe('v8debugapi', function() {
     '{f: process.env}',
     '1,2,3,{f:2},4',
     'A[this?this:1]',
-    '[1, 2, 3, 4, x == 1, x === 1, null, undefined]'
+    '[1, 2, 3, 4, x == 1, x === 1, null, undefined]',
+    '[0].values',
+    '[][0]',
+    '[0][' + MAX_INT + ']',
+    '"𠮷".length + (5| "𠮷")',
+    '/ٹوٹ بٹوٹ کے دو مُرغے تھے/',
   ]);
+
+  if (semver.satisfies(process.version, '>=4.0')) {
+    conditionTests('invalid conditions Node 4+', assert, [
+      '[][Symbol.iterator]()',
+      '`${[][Symbol.iterator]()}`',
+      '`${let x = 1}`',
+      '`${JSON.parse("{x:1}")}`',
+      '`${try {1}}`'
+    ]);
+    conditionTests('valid conditions Node 4+', function(err) {
+      assert.ifError(err);
+    }, [
+      '[][Symbol.iterator]',
+      '[..."peanut butter"]',
+      '[0,...[1,2,"foo"]]',
+      '`${1}`',
+      '`${[][1+1]}`',
+      '0b10101010',
+      '0o70000',
+      // Disabled because of suspect acorn issues?
+      // https://tonicdev.com/575b00351a0e0a1300505d00/575b00351a0e0a1300505d01
+      //'{["foo"]: 1}',
+      //'{ foo (a,b) {}}'
+    ]);
+  }
 
   describe('path normalization', function() {
     var breakpoints = [


### PR DESCRIPTION
We were previously rejecting ES6 expressions. Switch over acorn to ES6
mode and add a few tests.

@matthewloring,@cristiancavalli PTAL.