### PR TITLE
Add ability to read read receiver contexts

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -24,6 +24,18 @@ module.exports = {
 var assert = require('assert');
 var semver = require('semver');
 var util = require('util');
+var lodash = require('lodash');
+var isPlainObject = lodash.isPlainObject;
+var isFunction = lodash.isFunction;
+var isObject = lodash.isObject;
+var isArray = lodash.isArray;
+var has = lodash.has;
+var isNull = lodash.isNull;
+var isString = lodash.isString;
+var isNumber = lodash.isNumber;
+var isUndefined = lodash.isUndefined;
+var isBoolean = lodash.isBoolean;
+var keys = lodash.keys;
 
 var StatusMessage = require('./apiclasses.js').StatusMessage;
 
@@ -105,11 +117,40 @@ function evaluate(expression, frame) {
   }
 }
 
+/**
+ * The variable object is a rendering of an observed variable into an plain
+ * Javascript object with three properties which are consumed by the StackDriver
+ * API. This object must be used for any variable parsing which is sent to the
+ * StackDriver Debug API.
+ * @typedef {Object} APIVariable
+ * @property {String} name - the variables name
+ * @property {Any} value - the varaibles value
+ * @property {String} type - the variables type e.g: "String", "Object",
+ *  "Array", "Null", "Number"
+ */
+
+/**
+ * The scoped variable pool is a plain Javascript object that is used to track
+ * the relationship between a variable name and its value during the walking of
+ * each frames scoped variables. Since the scope topology is flattened for user
+ * viewing in the debug inspector this object should not contain scope->variable
+ * name->value topology, any duplicate variable names should either be ignored
+ * or overwrite the current variable name key inside of the pool. Each key in
+ * the pool should reflect an actual variables name and each value should be
+ * variables value.
+ * @typedef {Object} VariablePool
+ * @property {APIVariable} aVariableName - a dynamically allocated property
+ *  (note: aVariableName should be replaced with the actual variable name)
+ *  where the key is the variable name and the value is variable value as
+ *  represented by an instance of the APIVariable object type.
+ */
+
 
 /**
  * @param {!Object} execState
  * @param {Array<string>} expressions
  * @param {!Object} config
+ * @class StateResolver
  * @constructor
  */
 function StateResolver(execState, expressions, config) {
@@ -212,16 +253,430 @@ StateResolver.prototype.trimVariableTable_ = function(fromIndex, frames) {
 
 StateResolver.prototype.resolveFrames_ = function() {
   var frames = [];
+  var scopeVars = [];;
+  var resolveVars = false;
+  var frameResolution = {};
   var frameCount = Math.min(this.state_.frameCount(),
     this.config_.capture.maxFrames);
   for (var i = 0; i < frameCount; i++) {
+
     var frame = this.state_.frame(i);
     if (this.shouldFrameBeResolved_(frame)) {
-      var resolveVars = i < this.config_.capture.maxExpandFrames;
-      frames.push(this.resolveFrame_(frame, resolveVars));
+      scopeVars = this.extractScopeVars_(frame);
+      resolveVars = i < this.config_.capture.maxExpandFrames;
+      frameResolution = this.resolveFrame_(frame, resolveVars)
+      frameResolution.locals = frameResolution.locals.concat(scopeVars);
+      frames.push(frameResolution);
     }
   }
   return frames;
+};
+
+/**
+ * Extracts variables from the frames scope enumeration. Will also attempt to
+ * gather the `context` varaible from the current scope by looking at the
+ * receiver object. Will return an array containing relevant scope variables.
+ * @function extractScopeVars_
+ * @memberof StateResolver
+ * @param {FrameMirror} frame - a frame mirror object from the V8 debug API
+ * @returns {Array<APIVariable>} - returns an array of APIVariable object
+ *  instances for consumption by the StackDriver Debug API 
+ */
+StateResolver.prototype.extractScopeVars_ = function (frame) {
+  var scopes = frame.allScopes();
+  var scopedLocals = {};
+  var ctx =  this.marshalExtractedVarIntoAPIObject_(frame.details().receiver(),
+    "context", []);
+
+  // Attempt to extract the `this` context
+
+  if ( ctx.type === 'object' ) {
+    this.fuseScopedVarsToPool(
+      ctx
+      , scopedLocals
+    );
+  }
+
+  for (var i = 0; i < scopes.length; i++) {
+
+    switch (scopes[i].scopeType()) {
+      case 2: // WITH
+      case 4: // TRY/CATCH
+      case 5: // BLOCK
+      case 7: // EVAL
+        this.fuseScopedVarsToPool(
+          this.extractFromScopeDetails_(scopes[i]), scopedLocals);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return this.scopedPoolToList_(scopedLocals);
+}
+
+/**
+ * Adds variables to the scoped variable pool, which should be enumerated into
+ * a list for consumption by the Debug API. This function assumes that first
+ * frame parsed is root node on context tree, therefore if a scoped variable by
+ * name `x` is accumulated on the first frame pass and the second frame pass
+ * renders another varaible named `x` then the initial pass with that observed
+ * value will take precedence over the second frame pass and will not be
+ * overwritten by the second frames value. This function can accept either a
+ * list of scope variable renders or a singular scope variable render. This
+ * function will mutate the given scopedLocals varaible.
+ * @function fuseScopedVarsToPool
+ * @memberof StateResolver
+ * @param {APIVariable|Array<APIVariable>} scopeVars - the variable capture(s)
+ *  to add to the variable pool
+ * @param {VariablePool} scopedLocals - the variable pool accumulated so far
+ * @returns {Undefined} - does not return anything
+ */
+StateResolver.prototype.fuseScopedVarsToPool = function (scopeVars, scopedLocals) {
+  if (isArray(scopeVars)) {
+    for (var i = 0; i < scopeVars.length; i++) {
+      if (isObject(scopeVars[i]) && !has(scopedLocals, scopeVars[i].name)) {
+        // the lowest scope is first on the list, do not overwrite
+        scopedLocals[scopeVars[i].name] = scopeVars[i];
+      }
+    }
+  } else if (isPlainObject(scopeVars) && !has(scopedLocals, scopeVars.name)) {
+    if (!has(scopedLocals, scopeVars.name)) {
+      // the lowest scope is first on the list, do not overwrite
+      scopedLocals[scopeVars.name] = scopeVars;
+    }
+  }
+  // otherwise an input we can't deal with, defer mutating scopedLocals
+}
+
+/**
+ * Walks the scoped pools outer key and compiles it into a contiguous array
+ * without enforced concern for variable order since the scope topology is
+ * flattened for user viewing.
+ * @function scopedPoolToList_
+ * @memberof StateResolver
+ * @param {VariablePool} scopedLocals - the variable pool accumulated so far
+ * @returns {Array<APIVariable>} - returns an array of APIVariable instances
+ */
+StateResolver.prototype.scopedPoolToList_ = function (scopedLocals) {
+  var oKeys = keys(scopedLocals);
+  var returnArray = new Array(oKeys.length);
+
+  for ( var i = 0; i < oKeys.length; i++ ) {
+    returnArray[i] = scopedLocals[oKeys[i]];
+  }
+
+  return returnArray;
+}
+
+/**
+ * Iterates over the scope details object, creates an array and marshals in any
+ * extracted variables which should be instance of APIVariable and then returns
+ * this array.
+ * @function extractFromScopeDetails_
+ * @memberof StateResolver
+ * @param {ScopeMirror} scope - the ScopeMirror object from the FrameMirror
+ *  instance
+ * @returns {Array<APIVariable>} - returns an array of APIVariable instances
+ *  which were gathered by traversing the scope variables from the given frame
+ */
+StateResolver.prototype.extractFromScopeDetails_ = function (scope) {
+
+  var targetDetail = scope.details().object();
+  var oKeys = keys(targetDetail);
+  var extractedVars = [];
+
+  for ( var i = 0; i < oKeys.length; i++ ) {
+
+    extractedVars.push(
+      this.marshalExtractedVarIntoAPIObject_(targetDetail[oKeys[i]], oKeys[i],
+        [])
+    );
+  }
+
+  return extractedVars;
+}
+
+/**
+ * Attempts to determine the type of the variable that is being given for value
+ * extraction. If the type is found and supported then the given variable will
+ * be routed to the appropriate extraction function and the value returned to
+ * the extraction loop. Otherwise undefined will be returned and a warning
+ * logged.
+ * @function marshalExtractedVarIntoAPIObject_
+ * @memberof StateResolver
+ * @param {Any} scopeVar - the variable value to be extracted
+ * @param {String} varName - the name of the variable value to be extracted
+ * @param {Array<Object>|Undefined} [knownRefs] - a list of already known object
+ *  references, this parameter is used in recusrive calling of this function for
+ *  objects and arrays to avoid attempting to parse circular and/or nested-
+ *  circular objects
+ * @returns {APIVariable|Undefined} - will either return an instance of
+ *  APIVariable with extracted variable information or `Undefined` is the type
+ *  cannot be found or is not supported
+ */
+StateResolver.prototype.marshalExtractedVarIntoAPIObject_ = function (scopeVar, varName, knownRefs) {
+
+  switch (true) {
+    case isNumber(scopeVar):
+      return this.marshalNumberIntoAPIObject_(scopeVar, varName);
+    case isString(scopeVar):
+      return this.marshalStringIntoAPIObject_(scopeVar, varName);
+    case isBoolean(scopeVar):
+      return this.marshalBooleanIntoAPIObject_(scopeVar, varName);
+    case isUndefined(scopeVar):
+      return this.marshalUndefinedIntoAPIObject_(scopeVar, varName);
+    case isNull(scopeVar):
+      return this.marshalNullIntoAPIObject_(scopeVar, varName);
+    case isFunction(scopeVar):
+      return this.marshalFunctionIntoAPIObject_(scopeVar, varName);
+    case isArray(scopeVar):
+      return this.marshalArrayIntoAPIObject_(scopeVar, varName, knownRefs);
+    case isObject(scopeVar):
+      return this.marshalObjectIntoAPIObject_(scopeVar, varName, knownRefs);
+    default:
+      console.log("Unsupported type", typeof scopeVar);
+      return;
+  }
+}
+
+/**
+ * Given an object reference to check for and an array of references to check
+ * in - will return a boolean indicating whether or not the reference is present
+ * in the given array.
+ * @function checkForKnownRef_
+ * @memberof StateResolver
+ * @param {Any} toCheckFor - the reference to check for
+ * @param {Array<Object>} - the array to check the reference for
+ * @returns {Boolean} - returns true if the reference is present in the
+ *  given array
+ */
+StateResolver.prototype.checkForKnownRef_ = function (toCheckFor, knownRefs) {
+
+  return knownRefs.indexOf(toCheckFor) > -1;
+};
+
+/**
+ * Returns a plain Javascript object of type APIVariable which represents a
+ * Javascript number. The value field of the APIVariable instance must be
+ * converted to type string since the API only accepts string-typed values.
+ * @function marshalNumberIntoAPIObject_
+ * @memberof StateResolver
+ * @param {Number} scopeVar - the number value of the variable
+ * @param {String} varName - the name of the variable
+ * @returns {APIVariable} - returns an instance of APIVariable which represents
+ *  a number
+ */
+StateResolver.prototype.marshalNumberIntoAPIObject_ = function (scopeVar, varName) {
+
+  return ({
+    name: varName,
+    value: scopeVar.toString(),
+    type: "number"
+  });
+};
+
+/**
+ * Returns a plain Javascript object of type APIVariable which represents a
+ * Javascript string.
+ * @function marshalStringIntoAPIObject_
+ * @memberof StateResolver
+ * @param {String} scopeVar - the string value of the variable
+ * @param {String} varName - the name of the variable
+ * @returns {APIVariable} - returns an instance of APIVariable which represents
+ *  a string
+ */
+StateResolver.prototype.marshalStringIntoAPIObject_ = function (scopeVar, varName) {
+
+  return({
+    name: varName,
+    value: scopeVar,
+    type: "string"
+  });
+};
+
+/**
+ * Returns a plain Javascript object of type APIVariable which represents a
+ * Javascript boolean.
+ * @function marshalBooleanIntoAPIObject_
+ * @memberof StateResolver
+ * @param {Boolean} scopeVar - the boolean value of the variable
+ * @param {String} varName - the name of the variable
+ * @returns {APIVariable} - returns an instance of APIVariable which represents
+ *  a boolean
+ */
+StateResolver.prototype.marshalBooleanIntoAPIObject_ = function (scopeVar, varName) {
+
+  return({
+    name: varName,
+    value: scopeVar.toString(),
+    type: "boolean"
+  });
+};
+
+/**
+ * Returns a plain Javascript object of type APIVariable which represents an
+ * instance of Javascript undefined.
+ * @function marshalUndefinedIntoAPIObject_
+ * @memberof StateResolver
+ * @param {Undefined} scopeVar - the undefined value of the variable
+ * @param {String} varName - the name of the variable
+ * @returns {APIVariable} - returns an instance of APIVariable which represents
+ *  an instance of undefined
+ */
+StateResolver.prototype.marshalUndefinedIntoAPIObject_ = function (scopeVar, varName) {
+
+  return({
+    name: varName,
+    value: 'undefined',
+    type: 'undefined'
+  });
+};
+
+/**
+ * Returns a plain Javascript object of type APIVariable which represents a
+ * Javascript null type. The value field of the APIVariable instance must be
+ * converted to type string since the API only accepts string-typed values.
+ * @function marshalNullIntoAPIObject_
+ * @memberof StateResolver
+ * @param {Null} scopeVar - the null value of the variable
+ * @param {String} varName - the name of the variable
+ * @returns {APIVariable} - returns an instance of APIVariable which represents
+ *  null
+ */
+StateResolver.prototype.marshalNullIntoAPIObject_ = function (scopeVar, varName) {
+
+  return({
+    name: varName,
+    value: "null",
+    type: "null"
+  });
+};
+
+/**
+ * A stub for objects which contain circular references, instead of exceeding
+ * max stack calls a property which creates a circular reference is labelled as
+ * a string with the value `[circular]` to indicate that the value is circular.
+ * @function marhsalCircularIntoAPIObject_
+ * @memberof StateResolver
+ * @param {Object} scopeVar - the value of the circular reference
+ * @param {String} varName - the variable name to be labelled as circular
+ * @returns {APIVariable} - returns an instance of APIVariable which represents
+ *  a circular reference
+ */
+StateResolver.prototype.marhsalCircularIntoAPIObject_ = function (scopeVar, varName) {
+  var constructorName = 'Unknown Constructor';
+
+  if (isObject(scopeVar) && isObject(scopeVar.constructor)
+    && isString(scopeVar.constructor.name)) {
+
+    constructorName = scopeVar.constructor.name;    
+  }
+
+  return({
+    name: varName,
+    value: [constructorName, '[circular]'].join(': '),
+    type: 'string'
+  });
+};
+
+/**
+ * Returns a toString-ed function value for consumption by the API.
+ * @function marshalFunctionIntoAPIObject_
+ * @memberof StateResolver
+ * @param {Object} scopeVar - the toString-ed value of the function
+ * @param {String} varName - the variable name to be labelled as a function
+ * @returns {APIVariable} - returns an instance of APIVariable which represents
+ *  a function
+ */
+StateResolver.prototype.marshalFunctionIntoAPIObject_ = function (scopeVar, varName) {
+
+  return({
+    name: varName,
+    value: scopeVar.toString(),
+    type: 'function'
+  });
+};
+
+/**
+ * Returns a plain Javascript object of type APIVariable which represents a
+ * Javascript Array. This function will not cast its `members` value property
+ * to type string since this will be done by a JSON.stringify process called
+ * later in the StateResolver class.
+ * @function marshalArrayIntoAPIObject_
+ * @memberof StateResolver
+ * @param {Array<Any>} scopeVar - the variable to extract array data from
+ * @param {String} varName - the name of the variable to extract data from
+ * @param {Array<Object>} knownRefs - an array of already seen object references
+ * @returns {APIVariable} - returns a plain Javascript object of type
+ *  APIVariable representing an Array
+ */
+StateResolver.prototype.marshalArrayIntoAPIObject_ = function (scopeVar, varName, knownRefs) {
+  var self = this;
+
+  if (this.checkForKnownRef_(scopeVar, knownRefs)) {
+
+    return this.marhsalCircularIntoAPIObject_(scopeVar, varName);
+  }
+
+  knownRefs.push(scopeVar);
+
+  return ({
+    name: varName,
+    type: "array",
+    members: scopeVar.map(
+      function ( val, index ) {
+
+        return self.marshalExtractedVarIntoAPIObject_(val, index.toString(), knownRefs);
+      }
+    ).concat([
+      {
+        name: "length",
+        value: scopeVar.length.toString(),
+        type: "number"
+      }
+    ])
+  });
+};
+
+/**
+ * Returns a plain Javascript object of type APIVariable which represents a
+ * Javascript Plain Object. This function will not cast its `members` value 
+ * property to type string since this will be done by JSON.stringify process
+ * called later in the StateResolver class.
+ * @function marshalObjectIntoAPIObject_
+ * @memberof StateResolver
+ * @param {Object} scopeVar - the variable to extract object data from
+ * @param {String} varName - the name of the variable to extract data from
+ * @param {Array<Object>} knowRefs - an array of already seen object references
+ * @returns {APIVariable} - returns a plain Javascript object of type
+ *  APIVariable representing an Object
+ */
+StateResolver.prototype.marshalObjectIntoAPIObject_ = function (scopeVar, varName, knownRefs) {
+  var oKeys = [];
+  var membersArray = [];
+
+  if ( this.checkForKnownRef_(scopeVar, knownRefs) ) {
+
+    return this.marhsalCircularIntoAPIObject_(scopeVar, varName);
+  }
+
+  knownRefs.push(scopeVar);
+  oKeys = keys(scopeVar);
+
+  for ( var i = 0; i < oKeys.length; i++ ) {
+
+    membersArray.push(
+      this.marshalExtractedVarIntoAPIObject_(scopeVar[oKeys[i]],
+        oKeys[i].toString(), knownRefs)
+    );
+  }
+
+  return ({
+    name: varName,
+    type: "object",
+    members: membersArray
+  });
 };
 
 StateResolver.prototype.shouldFrameBeResolved_ = function(frame) {
@@ -285,6 +740,7 @@ StateResolver.prototype.resolveFrame_ = function(frame, resolveVars) {
     name: 'locals_not_available',
     varTableIndex: ARG_LOCAL_LIMIT_MESSAGE_INDEX
   }];
+
   return {
     function: this.resolveFunctionName_(frame.func()),
     location: this.resolveLocation_(frame),
@@ -395,6 +851,7 @@ StateResolver.prototype.getVariableIndex_ = function(value) {
   if (idx === -1) {
     idx = this.storeObjectToVariableTable_(value);
   }
+
   return idx;
 };
 

--- a/test/fixtures/basic-this.js
+++ b/test/fixtures/basic-this.js
@@ -1,0 +1,8 @@
+function obj ( ) {
+  this.o = true;
+  var o = false;
+
+  return o;
+};
+
+module.exports = obj;

--- a/test/fixtures/nested-this.js
+++ b/test/fixtures/nested-this.js
@@ -1,0 +1,13 @@
+function obj ( ) {
+  this.k = true;
+  this.j = function ( ) {
+    this.k = false;
+
+    return this.k;
+  };
+
+  this.j.bind({})();
+  return this.j;
+}
+
+module.exports = obj;


### PR DESCRIPTION
This commit adds the ability to read and display receiver contexts (e.g. `this`) when relevant