### PR TITLE
Make E2E tests ScopeMirror aware

### DIFF
--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -10,6 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "lodash": "^3.9.3",
-    "q": "^1.4.1"
+    "q": "^1.4.1",
+    "semver": "^5.3.0"
   }
 }

--- a/test/e2e/test.js
+++ b/test/e2e/test.js
@@ -28,6 +28,7 @@ var GoogleAuth = require('google-auth-library');
 var _ = require('lodash'); // for _.find. Can't use ES6 yet.
 var Q = require('q');
 var cluster = require('cluster');
+var semver = require('semver');
 
 var DEBUG_API = 'https://clouddebugger.googleapis.com/v2/debugger';
 var SCOPES = [
@@ -209,6 +210,7 @@ function runTest() {
         return promise;
       })
       .then(function(body) {
+        var arg;
         console.log('-- results of get breakpoint\n', body);
         assert.ok(body.breakpoint, 'should have a breakpoint in the response');
         var hit = body.breakpoint;
@@ -219,9 +221,11 @@ function runTest() {
         assert.ok(top.function, 'frame should have a function property');
         assert.strictEqual(top.function, 'fib');
 
-        var arg = _.find(top.arguments, function(a) {
-          return a.name === 'n';
-        });
+        if (semver.satisfies(process.version, '>=4.0')) {
+          arg = _.find(top.locals, {name: 'n'});
+        } else {
+          arg = _.find(top.arguments, {name: 'n'});
+        }
         assert.ok(arg, 'should find the n argument');
         assert.strictEqual(arg.value, '10');
         console.log('-- checking log point was hit again');


### PR DESCRIPTION
Add semver to dependencies for e2e tests. Add version
check in breakpoint fetch and compare to determine whether
or not to look in locals or arguments for target variable.

Fixes the build errors we've been receiving on pushes.