### PR TITLE
Add debuggee name to the re-register log message

### DIFF
--- a/lib/debuglet.js
+++ b/lib/debuglet.js
@@ -58,6 +58,9 @@ function Debuglet(config, logger) {
   /** @private {boolean} */
   this.running_ = false;
 
+  /** @private {string} */
+  this.project_ = null;
+
   /** @private {boolean} */
   this.fetcherActive_ = false;
 
@@ -108,7 +111,7 @@ Debuglet.prototype.start = function() {
 
       that.logger_.info('Unique ID for this Application: ' + id);
 
-      that.debugletApi_.init(id, that.logger_, function(err) {
+      that.debugletApi_.init(id, that.logger_, function(err, project) {
         if (err) {
           that.logger_.error('Unable to initialize the debuglet api' +
             ' -- disabling debuglet', err);
@@ -126,6 +129,7 @@ Debuglet.prototype.start = function() {
 
         // We can register as a debuggee now.
         that.running_ = true;
+        that.project_ = project;
         that.scheduleRegistration_(0 /* immediately */);
         that.emit('started');
       });
@@ -141,7 +145,8 @@ Debuglet.prototype.scheduleRegistration_ = function(seconds) {
   var that = this;
 
   function onError(err) {
-    that.logger_.error('Failed to re-register debuggee: ' + err);
+    that.logger_.error('Failed to re-register debuggee ' +
+      that.project_ + ': ' + err);
     that.scheduleRegistration_(Math.min((seconds + 1) * 2,
       that.config_.internal.maxRegistrationRetryDelay));
   }

--- a/lib/debugletapi.js
+++ b/lib/debugletapi.js
@@ -71,7 +71,7 @@ DebugletApi.prototype.init = function(uid, logger, callback) {
 
   function complete(err, project) {
     if (err) {
-      callback(err);
+      callback(err, project);
       return;
     }
     that.project_ = project;

--- a/lib/debugletapi.js
+++ b/lib/debugletapi.js
@@ -83,7 +83,7 @@ DebugletApi.prototype.init = function(uid, logger, callback) {
         logger.warn('Malformed source-context.json file.');
         // But we keep on going.
       }
-      callback(null);
+      callback(null, project);
     });
   }
 

--- a/test/test-debugletapi.js
+++ b/test/test-debugletapi.js
@@ -53,18 +53,12 @@ describe('Debuglet API', function() {
   });
 
   it('should acquire the project number during init', function(done) {
-    var PROJECT = 'project123';
-    var oldProjNum = utils.getProjectNumber;
-    utils.getProjectNumber = function(callback) {
-      callback(null, PROJECT);
-    };
     debugletapi.init('uid123', { warn: function() {} }, function(err, project) {
       assert(!err);
       // make sure init() invokes the callback with the correct project name
-      assert.equal(project, PROJECT);
+      assert.equal(project, 'project123');
       // make sure the debugletapi is properly storing the project name
       assert.equal(debugletapi.project_, project);
-      utils.getProjectNumber = oldProjNum;
       done();
     });
   });

--- a/test/test-debugletapi.js
+++ b/test/test-debugletapi.js
@@ -53,7 +53,7 @@ describe('Debuglet API', function() {
   });
 
   it('should acquire the project number during init', function(done) {
-    debugletapi.init('uid123', { warn: function() {} }, function(err) {
+    debugletapi.init('uid123', { warn: function() {} }, function(err, project) {
       assert(!err);
       done();
     });
@@ -86,7 +86,7 @@ describe('Debuglet API', function() {
       };
       process.GCLOUD_PROJECT = 'project123';
       var debugletapi = new DebugletApi();
-      debugletapi.init('uid1234', { warn: function() {} }, function(err) {
+      debugletapi.init('uid1234', { warn: function() {} }, function(err, project) {
         var scope = nock(url)
           .post(api + '/debuggees/register', function (body) {
             return body.debuggee.agentVersion ===

--- a/test/test-debugletapi.js
+++ b/test/test-debugletapi.js
@@ -55,6 +55,7 @@ describe('Debuglet API', function() {
   it('should acquire the project number during init', function(done) {
     debugletapi.init('uid123', { warn: function() {} }, function(err, project) {
       assert(!err);
+      assert.equal(debugletapi.project_, project);
       done();
     });
   });

--- a/test/test-debugletapi.js
+++ b/test/test-debugletapi.js
@@ -53,9 +53,18 @@ describe('Debuglet API', function() {
   });
 
   it('should acquire the project number during init', function(done) {
+    var PROJECT = 'project123';
+    var oldProjNum = utils.getProjectNumber;
+    utils.getProjectNumber = function(callback) {
+      callback(null, PROJECT);
+    };
     debugletapi.init('uid123', { warn: function() {} }, function(err, project) {
       assert(!err);
+      // make sure init() invokes the callback with the correct project name
+      assert.equal(project, PROJECT);
+      // make sure the debugletapi is properly storing the project name
       assert.equal(debugletapi.project_, project);
+      utils.getProjectNumber = oldProjNum;
       done();
     });
   });

--- a/test/test-debugletapi.js
+++ b/test/test-debugletapi.js
@@ -21,6 +21,10 @@ var request = require('request');
 var proxyquire = require('proxyquire');
 var agentVersion = require('../package.json').version;
 
+// the tests in this file rely on the GCLOUD_PROJECT environment variable
+// not being set
+delete process.env.GCLOUD_PROJECT;
+
 // require DebugletAPI while stubbing auth to bypass authentication
 //
 var utils = {
@@ -88,7 +92,7 @@ describe('Debuglet API', function() {
       utils.getProjectNumber = function(callback) {
         callback(new Error(), null);
       };
-      process.GCLOUD_PROJECT = 'project123';
+      process.env.GCLOUD_PROJECT = 'project123';
       var debugletapi = new DebugletApi();
       debugletapi.init('uid1234', { warn: function() {} }, function(err, project) {
         var scope = nock(url)
@@ -105,7 +109,7 @@ describe('Debuglet API', function() {
           assert.equal(result.debuggee.id, 'fake-debuggee');
           assert.equal(debugletapi.debuggeeId_, 'fake-debuggee');
           scope.done();
-          delete process.GCLOUD_PROJECT;
+          delete process.env.GCLOUD_PROJECT;
           utils.getProjectNumber = oldProjNum;
           done();
         });


### PR DESCRIPTION
If an error occurs when re-registering a debuggee, the name of
the debuggee is reported in the error message to aid in debugging
why the re-registration failed.

fixes #128