### PR TITLE
Added keyFilename/credentials to config object

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,28 @@ If your application is running outside of Google Cloud Platform, such as locally
 
         export GCLOUD_PROJECT=<project name>
 
-2. You need to provide service account credentials to your application.
+1. You need to provide service account credentials to your application.
   * The recommended way is via [Application Default Credentials][app-default-credentials].
     1. [Create a new JSON service account key][service-account].
-    2. Copy the key somewhere your application can access it. Be sure not to expose the key publicly.
-    3. Set the environment variable `GOOGLE_APPLICATION_CREDENTIALS` to the full path to the key. The debug agent will automatically look for this environment variable.
+    1. Copy the key somewhere your application can access it. Be sure not to expose the key publicly.
+    1. Set the environment variable `GOOGLE_APPLICATION_CREDENTIALS` to the full path to the key. The debug agent will automatically look for this environment variable.
   * If you are running your application on a machine where your are using the [`gcloud` command line tools][gcloud-sdk], and are logged using `gcloud auth login`, you already have sufficient credentials, and a service account key is not required.
-  * Alternatively, you may set the keyFilename or credentials configuration field to the full path or contents to the key file, respectively. Setting either of these fields will override either setting GOOGLE_APPLICATION_CREDENTIALS or logging in using gcloud. (See the [default configuration](https://github.com/GoogleCloudPlatform/cloud-debug-nodejs/blob/master/config.js) for more details.)
+  * Alternatively, you may set the keyFilename or credentials configuration field to the full path or contents to the key file, respectively. Setting either of these fields will override either setting GOOGLE_APPLICATION_CREDENTIALS or logging in using gcloud. For example:
 
-3. Generate a `source-context.json` file which contains information about the version of the source code used to build the application. This file should be located in the root directory of your application. When you open the Stackdriver Debugger in the Cloud Platform Console, it uses the information in this file to display the correct version of the source.
+    ```js
+    // Require and start the agent with configuration options
+    require('@google/cloud-debug').start({
+      // The path to your key file:
+      keyFilename: '/path/to/keyfile.json',
+
+      // Or the contents of the key file:
+      credentials: require('./path/to/keyfile.json')
+    });
+    ```
+    
+    See the [default configuration](https://github.com/GoogleCloudPlatform/cloud-debug-nodejs/blob/master/config.js) for more details.
+
+1. Generate a `source-context.json` file which contains information about the version of the source code used to build the application. This file should be located in the root directory of your application. When you open the Stackdriver Debugger in the Cloud Platform Console, it uses the information in this file to display the correct version of the source.
 
         gcloud app gen-repo-info-file
 

--- a/README.md
+++ b/README.md
@@ -53,15 +53,15 @@ If your application is running outside of Google Cloud Platform, such as locally
 
         export GCLOUD_PROJECT=<project name>
 
-2. You need to provide service account credentials to your application. The recommended way is via [Application Default Credentials][app-default-credentials].
+2. You need to provide service account credentials to your application.
+  * The recommended way is via [Application Default Credentials][app-default-credentials].
+    1. [Create a new JSON service account key][service-account].
+    2. Copy the key somewhere your application can access it. Be sure not to expose the key publicly.
+    3. Set the environment variable `GOOGLE_APPLICATION_CREDENTIALS` to the full path to the key. The debug agent will automatically look for this environment variable.
+  * If you are running your application on a machine where your are using the [`gcloud` command line tools][gcloud-sdk], and are logged using `gcloud auth login`, you already have sufficient credentials, and a service account key is not required.
+  * Alternatively, you may set the keyFilename or credentials configuration field to the full path or contents to the key file, respectively. Setting either of these fields will override either setting GOOGLE_APPLICATION_CREDENTIALS or logging in using gcloud. (See the [default configuration](https://github.com/GoogleCloudPlatform/cloud-debug-nodejs/blob/master/config.js) for more details.)
 
-  1. [Create a new JSON service account key][service-account].
-  2. Copy the key somewhere your application can access it. Be sure not to expose the key publicly.
-  3. Set the environment variable `GOOGLE_APPLICATION_CREDENTIALS` to the full path to the key. The debug agent will automatically look for this environment variable.
-
-3. Alternatively, if you are running your application on a machine where your are using the [`gcloud` command line tools][gcloud-sdk], and are logged using `gcloud auth login`, you already have sufficient credentials, and a service account key is not required.
-
-4. Generate a `source-context.json` file which contains information about the version of the source code used to build the application. This file should be located in the root directory of your application. When you open the Stackdriver Debugger in the Cloud Platform Console, it uses the information in this file to display the correct version of the source.
+3. Generate a `source-context.json` file which contains information about the version of the source code used to build the application. This file should be located in the root directory of your application. When you open the Stackdriver Debugger in the Cloud Platform Console, it uses the information in this file to display the correct version of the source.
 
         gcloud app gen-repo-info-file
 

--- a/config.js
+++ b/config.js
@@ -76,6 +76,16 @@ module.exports = {
       logDelaySeconds: 1
     },
 
+    // A path to a key file relative to the current working directory. If this
+    // field is set, the contents of the pointed file will be used for
+    // authentication instead of your application default credentials.
+    keyFilename: null,
+
+    // The contents of a key file. If this field is set, its contents will be
+    // used for authentication instead of your application default credentials.
+    // If keyFilename is also set, the value of credentials will be ignored.
+    credentials: null,
+
     // These configuration options are for internal experimentation only.
     internal: {
       registerDelayOnFetcherErrorSec: 300, // 5 minutes.

--- a/lib/debugletapi.js
+++ b/lib/debugletapi.js
@@ -45,7 +45,10 @@ function DebugletApi(config) {
   var config_ = config || {};
 
   /** @private {Object} request style request object */
-  this.request_ = utils.authorizedRequestFactory(SCOPES);
+  this.request_ = utils.authorizedRequestFactory(SCOPES, {
+    keyFile: config_.keyFilename,
+    credentials: config_.credentials
+  });
 
   /** @private {string} numeric project id */
   this.project_ = null;

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "proxyquire": "^1.4.0"
   },
   "dependencies": {
-    "@google/cloud-diagnostics-common": "0.2.5",
+    "@google/cloud-diagnostics-common": "0.3.0",
     "acorn": "^3.3.0",
     "async": "^2.1.2",
     "coffee-script": "^1.9.3",

--- a/test/fixtures/gcloud-credentials.json
+++ b/test/fixtures/gcloud-credentials.json
@@ -1,0 +1,6 @@
+{
+  "client_id": "x",
+  "client_secret": "y",
+  "refresh_token": "z",
+  "type": "authorized_user"
+}

--- a/test/standalone/test-config-credentials.js
+++ b/test/standalone/test-config-credentials.js
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var path = require('path');
+var assert = require('assert');
+var nock = require('nock');
+
+process.env.GCLOUD_PROJECT = 0;
+
+describe('test-config-credentials', function() {
+  it('should use the keyFilename field of the config object', function(done) {
+    var credentials = require('../fixtures/gcloud-credentials.json');
+    var config = {
+      keyFilename: path.join('test', 'fixtures', 'gcloud-credentials.json')
+    };
+    var agent = require('../..');
+    nock.disableNetConnect();
+    var scope = nock('https://accounts.google.com')
+      .post('/o/oauth2/token', function(body) {
+        assert.equal(body.client_id, credentials.client_id);
+        assert.equal(body.client_secret, credentials.client_secret);
+        assert.equal(body.refresh_token, credentials.refresh_token);
+        return true;
+      }).reply(200, {
+        refresh_token: 'hello',
+        access_token: 'goodbye',
+        expiry_date: new Date(9999, 1, 1)
+      });
+    // Since we have to get an auth token, this always gets intercepted second
+    nock('https://clouddebugger.googleapis.com')
+      .post('/v2/controller/debuggees/register', function() {
+        scope.done();
+        agent.start.wasSuccessful_ = false;
+        setImmediate(done);
+        return true;
+      }).reply(200);
+    agent.start(config);
+  });
+
+  it('should use the credentials field of the config object', function(done) {
+    var config = {
+      credentials: require('../fixtures/gcloud-credentials.json')
+    };
+    var agent = require('../..');
+    nock.disableNetConnect();
+    var scope = nock('https://accounts.google.com')
+      .post('/o/oauth2/token', function(body) {
+        assert.equal(body.client_id, config.credentials.client_id);
+        assert.equal(body.client_secret, config.credentials.client_secret);
+        assert.equal(body.refresh_token, config.credentials.refresh_token);
+        return true;
+      }).reply(200, {
+        refresh_token: 'hello',
+        access_token: 'goodbye',
+        expiry_date: new Date(9999, 1, 1)
+      });
+    // Since we have to get an auth token, this always gets intercepted second
+    nock('https://clouddebugger.googleapis.com')
+      .post('/v2/controller/debuggees/register', function() {
+        scope.done();
+        agent.start.wasSuccessful_ = false;
+        setImmediate(done);
+        return true;
+      }).reply(200);
+    agent.start(config);
+  });
+
+  it('should ignore credentials if keyFilename is provided', function(done) {
+    var correctCredentials = require('../fixtures/gcloud-credentials.json');
+    var config = {
+      keyFilename: path.join('test', 'fixtures', 'gcloud-credentials.json'),
+      credentials: {
+        client_id: 'a',
+        client_secret: 'b',
+        refresh_token: 'c',
+        type: 'authorized_user'
+      }
+    };
+    ['client_id', 'client_secret', 'refresh_token'].forEach(function (field) {
+      assert(correctCredentials.hasOwnProperty(field));
+      assert(config.credentials.hasOwnProperty(field));
+      assert.notEqual(config.credentials[field],
+        correctCredentials[field]);
+    });
+    var agent = require('../..');
+    nock.disableNetConnect();
+    var scope = nock('https://accounts.google.com')
+      .post('/o/oauth2/token', function(body) {
+        assert.equal(body.client_id, correctCredentials.client_id);
+        assert.equal(body.client_secret, correctCredentials.client_secret);
+        assert.equal(body.refresh_token, correctCredentials.refresh_token);
+        return true;
+      }).reply(200, {
+        refresh_token: 'hello',
+        access_token: 'goodbye',
+        expiry_date: new Date(9999, 1, 1)
+      });
+    // Since we have to get an auth token, this always gets intercepted second
+    nock('https://clouddebugger.googleapis.com')
+      .post('/v2/controller/debuggees/register', function() {
+        scope.done();
+        agent.start.wasSuccessful_ = false;
+        setImmediate(done);
+        return true;
+      }).reply(200);
+    agent.start(config);
+  });
+});


### PR DESCRIPTION
Clients may use config.keyFilename and config.credentials to supply a key file or its contents in lieu of GCLOUD_APPLICATION_CREDENTIALS.

See also: https://github.com/GoogleCloudPlatform/cloud-trace-nodejs/pull/315