### PR TITLE
Add a configuration section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,22 +27,10 @@ Deploy your application, and navigate to the [Stackdriver Debug view][debug-tab]
 
 ## Configuration
 
-First, some configuration options can be specified through environment variables:
-
-* `GCLOUD_DEBUG_DISABLE` specifies whether to enable or disable the agent
-* `GCLOUD_DEBUG_LOGLEVEL` specifies the debug level
-* `GCLOUD_DEBUG_REPO_APP_PATH` specifies the path within your repository to the directory containing the `package.json` for your deployed application
-* `GAE_MODULE_NAME` specifies the service name of the deployed application
-* `GAE_MODULE_VERSION` specifies the version of the deployed application
-
-Next, see [the default configuration](config.js) for a list of possible configuration options. These options can be passed to the agent through the object argument to the start command as shown below:
+See [the default configuration](config.js) for a list of possible configuration options. These options can be passed to the agent through the object argument to the start command as shown below:
 ```
 require('@google/cloud-debug').start({logLevel: 2});
 ```
-
-Last, you can also provide configuration through a config file.  You can start by copying the default config file and modifying it to suit your needs. The `GCLOUD_DIAGNOSTICS_CONFIG` environment variable should point to your configuration file.
-
-Note that configuration options specified through environment variables take precedence over options passed to the start command, which take precedence over options specified in a config file.
 
 ## Running on Google Cloud Platform
 

--- a/README.md
+++ b/README.md
@@ -25,19 +25,6 @@ require('@google/cloud-debug').start();
 ```
 Deploy your application, and navigate to the [Stackdriver Debug view][debug-tab] within the [Google Cloud Console][dev-console] to set snapshots and start debugging.
 
-## Configuration
-
-See [the default configuration](config.js) for a list of possible configuration options. These options can be passed to the agent through the object argument to the start command as shown below:
-```
-require('@google/cloud-debug').start({
-  logLevel: 2,
-  serviceContext: {
-      service: 'my-service',
-      version: '1'
-    }
-});
-```
-
 ## Running on Google Cloud Platform
 
 There are three different services that can host Node.js application to Google Cloud Platform.
@@ -77,6 +64,18 @@ If your application is running outside of Google Cloud Platform, such as locally
 4. Generate a `source-context.json` file which contains information about the version of the source code used to build the application. This file should be located in the root directory of your application. When you open the Stackdriver Debugger in the Cloud Platform Console, it uses the information in this file to display the correct version of the source.
 
         gcloud app gen-repo-info-file
+
+## Configuration
+
+See [the default configuration](config.js) for a list of possible configuration options. These options can be passed to the agent through the object argument to the start command as shown below:
+
+        require('@google/cloud-debug').start({
+          logLevel: 2,
+          serviceContext: {
+              service: 'my-service',
+              version: '1'
+            }
+        });
 
 ## Using the Debugger
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,29 @@ This module provides Stackdriver Debugger support for Node.js applications. [Sta
 # Install with `npm` or add to your `package.json`.
 npm install --save @google/cloud-debug
 
-# Require the agent at the top of your main script (but after '@google/cloud-trace' if you are also using it).
-require('@google/cloud-debug');
+# Require and start the agent at the top of your main script (but after '@google/cloud-trace' if you are also using it).
+require('@google/cloud-debug').start();
 ```
 Deploy your application, and navigate to the [Stackdriver Debug view][debug-tab] within the [Google Cloud Console][dev-console] to set snapshots and start debugging.
+
+## Configuration
+
+First, some configuration options can be specified through environment variables:
+
+* `GCLOUD_DEBUG_DISABLE` specifies whether to enable or disable the agent
+* `GCLOUD_DEBUG_LOGLEVEL` specifies the debug level
+* `GCLOUD_DEBUG_REPO_APP_PATH` specifies the path within your repository to the directory containing the `package.json` for your deployed application
+* `GAE_MODULE_NAME` specifies the service name of the deployed application
+* `GAE_MODULE_VERSION` specifies the version of the deployed application
+
+Next, see [the default configuration](config.js) for a list of possible configuration options. These options can be passed to the agent through the object argument to the start command as shown below:
+```
+require('@google/cloud-debug').start({logLevel: 2});
+```
+
+Last, you can also provide configuration through a config file.  You can start by copying the default config file and modifying it to suit your needs. The `GCLOUD_DIAGNOSTICS_CONFIG` environment variable should point to your configuration file.
+
+Note that configuration options specified through environment variables take precedence over options passed to the start command, which take precedence over options specified in a config file.
 
 ## Running on Google Cloud Platform
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ Deploy your application, and navigate to the [Stackdriver Debug view][debug-tab]
 
 See [the default configuration](config.js) for a list of possible configuration options. These options can be passed to the agent through the object argument to the start command as shown below:
 ```
-require('@google/cloud-debug').start({logLevel: 2});
+require('@google/cloud-debug').start({
+  logLevel: 2,
+  serviceContext: {
+      service: 'my-service',
+      version: '1'
+    }
+});
 ```
 
 ## Running on Google Cloud Platform

--- a/config.js
+++ b/config.js
@@ -24,6 +24,14 @@ module.exports = {
     // An identifier for the current code deployment.
     description: undefined,
 
+    serviceContext: {
+      // An identifier for the deployed application's service name
+      service: undefined,
+
+      // An identifier for the deployed application's version
+      version: undefined
+    },
+
     // The path within your repository to the directory containing the
     // package.json for your deployed application. This should be provided
     // if your deployed application appears as a subdirectory of your repository.


### PR DESCRIPTION
This PR adds a configuration section to the README file that should have been added in PR [#167](https://github.com/GoogleCloudPlatform/cloud-debug-nodejs/pull/167).