### PR TITLE
Update the gen-repo-info-file command

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If your application is running outside of Google Cloud Platform, such as locally
 
 1. Generate a `source-context.json` file which contains information about the version of the source code used to build the application. This file should be located in the root directory of your application. When you open the Stackdriver Debugger in the Cloud Platform Console, it uses the information in this file to display the correct version of the source.
 
-        gcloud app gen-repo-info-file
+        gcloud beta debug source gen-repo-info-file
 
 ## Configuration
 


### PR DESCRIPTION
New version: https://cloud.google.com/sdk/gcloud/reference/beta/debug/source/gen-repo-info-file