### PR TITLE
Correct the status shown if maxDataSize is reached

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -218,6 +218,7 @@ StateResolver.prototype.trimVariableTable_ = function(fromIndex, frames) {
       if (variable.varTableIndex && variable.varTableIndex >= fromIndex) {
         // make it point to the sentinel 'buffer full' value
         variable.varTableIndex = BUFFER_FULL_MESSAGE_INDEX;
+        variable.status = MESSAGE_TABLE[BUFFER_FULL_MESSAGE_INDEX].status;
       }
       if (variable.members) {
         processBufferFull(variable.members);


### PR DESCRIPTION
If a watched expression is collected that causes the `config.capture.maxDataSize` limit to be reached, local variables may not be collected, but the status message associated with the local variable would be incorrect.  In particular, if the local was an array, the message would describe that only the first `config.capture.maxProperties` items were captured.  This PR corrects this so that the status message is instead 'Max data size reached'.