### PR TITLE
improve UX for truncated objects properties

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -39,9 +39,8 @@ var BUFFER_FULL_MESSAGE_INDEX = 0;
 var NATIVE_PROPERTY_MESSAGE_INDEX = 1;
 var GETTER_MESSAGE_INDEX = 2;
 var ARG_LOCAL_LIMIT_MESSAGE_INDEX = 3;
-var OBJECT_LIMIT_MESSAGE_INDEX = 4;
-var STRING_LIMIT_MESSAGE_INDEX = 5;
-var DATA_LIMIT_MESSAGE_INDEX = 6;
+var STRING_LIMIT_MESSAGE_INDEX = 4;
+var DATA_LIMIT_MESSAGE_INDEX = 5;
 
 var MESSAGE_TABLE = [];
 MESSAGE_TABLE[BUFFER_FULL_MESSAGE_INDEX] =
@@ -58,11 +57,6 @@ MESSAGE_TABLE[ARG_LOCAL_LIMIT_MESSAGE_INDEX] =
                               'Locals and arguments are only displayed for the ' +
                               'top `config.capture.maxExpandFrames` stack frames.',
                                 true) };
-MESSAGE_TABLE[OBJECT_LIMIT_MESSAGE_INDEX] =
-  { status: new StatusMessage(StatusMessage.VARIABLE_VALUE,
-                              'Only first `config.capture.maxProperties` elements' +
-                              ' were captured.',
-                                false) };
 MESSAGE_TABLE[STRING_LIMIT_MESSAGE_INDEX] =
   { status: new StatusMessage(StatusMessage.VARIABLE_VALUE,
                               'Only first `config.capture.maxStringLength` chars' +
@@ -474,15 +468,8 @@ StateResolver.prototype.resolveVariable_ = function(name, value) {
 
   } else if (value.isFunction()) {
     data.value = 'function ' + this.resolveFunctionName_(value) + '()';
-
   } else if (value.isObject()) {
     data.varTableIndex = this.getVariableIndex_(value);
-    var maxProps = this.config_.capture.maxProperties;
-    var numKeys = Object.keys(value.value()).length;
-
-    if (maxProps && maxProps < numKeys) {
-      data.status = MESSAGE_TABLE[OBJECT_LIMIT_MESSAGE_INDEX].status;
-    }
   } else {
     // PropertyMirror, InternalPropertyMirror, FrameMirror, ScriptMirror
     data.value = 'unknown mirror type';
@@ -538,18 +525,22 @@ StateResolver.prototype.resolveMirrorSlow_ = function(mirror) {
 
   var keys = Object.keys(mirror.value());
   var maxProps = that.config_.capture.maxProperties;
-
-  if (maxProps) {
+  var truncate = maxProps && keys.length > maxProps;
+  if (truncate) {
     keys = keys.slice(0, maxProps);
   }
   var members = keys.map(function(prop) {
     return that.resolveMirrorProperty_(mirror.property(prop));
   });
+  if (truncate) {
+    members.push({name: 'Only first `config.capture.maxProperties` ' + 
+                        'properties were captured'});
+  }
 
   var mirrorVal = mirror.value();
   var len = mirrorVal && mirrorVal.length;
   return {
-    value: mirror.toText() + 
+    value: mirror.toText() +
       ((typeof len === 'undefined') ? '' : ' of length ' + len),
     members: members
   };
@@ -559,18 +550,20 @@ StateResolver.prototype.resolveMirrorSlow_ = function(mirror) {
 //
 // See https://github.com/iojs/io.js/issues/1190.
 StateResolver.prototype.resolveMirrorFast_ = function(mirror) {
-  var members = this.getMirrorProperties_(mirror).map(
-      this.resolveMirrorProperty_.bind(this));
+  var properties = mirror.properties();
+  var maxProps = this.config_.capture.maxProperties;
+  var truncate = maxProps && properties.length > maxProps;
+  if (truncate) {
+    properties = properties.slice(0, maxProps);
+  }
+  var members = properties.map(this.resolveMirrorProperty_.bind(this));
+  if (truncate) {
+    members.push({name: 'Only first maxProperties properties were captured'});
+  }
   return {
     value: mirror.toText(),
     members: members
   };
-};
-
-StateResolver.prototype.getMirrorProperties_ = function(mirror) {
-  var numProperties = this.config_.capture.maxProperties;
-  var properties = mirror.properties();
-  return numProperties ? properties.slice(0, numProperties) : properties;
 };
 
 StateResolver.prototype.resolveMirrorProperty_ = function(property) {

--- a/test/standalone/test-try-catch.js
+++ b/test/standalone/test-try-catch.js
@@ -89,16 +89,13 @@ describe('v8debugapi', function() {
             {name: 'e', value: 'undefined'}
           );
         } else {
-          assert.deepEqual(
-            locals[0],
-            {name: 'e', varTableIndex: 7}
-          );
+          var e = locals[0];
+          assert(e.name === 'e');
+          assert(Number.isInteger(e.varTableIndex));
         }
-        
-        assert.deepEqual(
-          args[0],
-          {name: 'arguments_not_available', varTableIndex: 3}
-        );
+        var arg0 = args[0];
+        assert(arg0.name === 'arguments_not_available');
+        assert(Number.isInteger(arg0.varTableIndex));      
         api.clear(brk);
         done();
       });
@@ -130,10 +127,9 @@ describe('v8debugapi', function() {
             locals[0],
             {name: 'e', value: '2'}
           );
-          assert.deepEqual(
-            args[0],
-            {name: 'arguments_not_available', varTableIndex: 3}
-          );
+          var arg0 = args[0];
+          assert(arg0.name === 'arguments_not_available');
+          assert(Number.isInteger(arg0.varTableIndex));
         }
         api.clear(brk);
         done();

--- a/test/test-v8debugapi.js
+++ b/test/test-v8debugapi.js
@@ -660,7 +660,9 @@ describe('v8debugapi', function() {
           assert.equal(procEnv.name, 'process.env');
           var envVal = bp.variableTable[procEnv.varTableIndex];
           envVal.members.forEach(function(member) {
-            assert(bp.variableTable[member.varTableIndex].status.isError);
+            if (member.varTableIndex) {
+               assert(bp.variableTable[member.varTableIndex].status.isError);
+            }
           });
           var hasGetter = bp.evaluatedExpressions[1];
           var getterVal = bp.variableTable[hasGetter.varTableIndex];
@@ -757,10 +759,9 @@ describe('v8debugapi', function() {
           assert.ifError(err);
           var foo = bp.evaluatedExpressions[0];
           var fooVal = bp.variableTable[foo.varTableIndex];
-          assert.equal(fooVal.members.length, 1);
-          assert(foo.status.description.format.indexOf(
-            'Only first') !== -1);
-          assert(!foo.status.isError);
+          // should have 1 element + truncation message.
+          assert.equal(fooVal.members.length, 2);
+          assert(fooVal.members[1].name.indexOf('Only first') !== -1);
 
           api.clear(bp);
           config.capture.maxProperties = oldMax;
@@ -784,7 +785,8 @@ describe('v8debugapi', function() {
           assert.ifError(err);
           var foo = bp.evaluatedExpressions[0];
           var fooVal = bp.variableTable[foo.varTableIndex];
-          assert.equal(fooVal.members.length, 1);
+          // should have 1 element + truncation message
+          assert.equal(fooVal.members.length, 2);
           assert(foo.status.description.format.indexOf(
             'Only first') !== -1);
           assert(!foo.status.isError);

--- a/test/test-v8debugapi.js
+++ b/test/test-v8debugapi.js
@@ -787,9 +787,7 @@ describe('v8debugapi', function() {
           var fooVal = bp.variableTable[foo.varTableIndex];
           // should have 1 element + truncation message
           assert.equal(fooVal.members.length, 2);
-          assert(foo.status.description.format.indexOf(
-            'Only first') !== -1);
-          assert(!foo.status.isError);
+          assert(fooVal.members[1].name.indexOf('Only first') !== -1);
 
           api.clear(bp);
           config.capture.maxProperties = oldMax;

--- a/test/test-v8debugapi.js
+++ b/test/test-v8debugapi.js
@@ -660,7 +660,7 @@ describe('v8debugapi', function() {
           assert.equal(procEnv.name, 'process.env');
           var envVal = bp.variableTable[procEnv.varTableIndex];
           envVal.members.forEach(function(member) {
-            if (member.varTableIndex) {
+            if (member.hasOwnProperty('varTableIndex')) {
                assert(bp.variableTable[member.varTableIndex].status.isError);
             }
           });


### PR DESCRIPTION
Change how we indicate that an object with too many properties has been
truncated on our state captures. Instead of a non-error StatusMessage
add an extra member with no value / varTableIndex. This matches how the
Java agent deals with this situation.

Original:
![image](https://cloud.githubusercontent.com/assets/79017/20247161/1f3b01de-a97a-11e6-8757-2663755aa561.png)

Now: 
![image](https://cloud.githubusercontent.com/assets/79017/20247230/d6533228-a97b-11e6-9416-b30e6a9f0bce.png)

and:
![image](https://cloud.githubusercontent.com/assets/79017/20247233/e6799fa2-a97b-11e6-892e-fbf9f742fd80.png)

R= @DominicKramer @cristiancavalli 