### PR TITLE
Now status messages include config values

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -40,33 +40,6 @@ var NATIVE_PROPERTY_MESSAGE_INDEX = 1;
 var GETTER_MESSAGE_INDEX = 2;
 var ARG_LOCAL_LIMIT_MESSAGE_INDEX = 3;
 var STRING_LIMIT_MESSAGE_INDEX = 4;
-var DATA_LIMIT_MESSAGE_INDEX = 5;
-
-var MESSAGE_TABLE = [];
-MESSAGE_TABLE[BUFFER_FULL_MESSAGE_INDEX] =
-  { status: new StatusMessage(StatusMessage.VARIABLE_VALUE,
-                              'Max data size reached', true) };
-MESSAGE_TABLE[NATIVE_PROPERTY_MESSAGE_INDEX] =
-  { status: new StatusMessage(StatusMessage.VARIABLE_VALUE,
-                              'Native properties are not available', true) };
-MESSAGE_TABLE[GETTER_MESSAGE_INDEX] =
-  { status: new StatusMessage(StatusMessage.VARIABLE_VALUE,
-                              'Properties with getters are not available', true) };
-MESSAGE_TABLE[ARG_LOCAL_LIMIT_MESSAGE_INDEX] =
-  { status: new StatusMessage(StatusMessage.VARIABLE_VALUE,
-                              'Locals and arguments are only displayed for the ' +
-                              'top `config.capture.maxExpandFrames` stack frames.',
-                                true) };
-MESSAGE_TABLE[STRING_LIMIT_MESSAGE_INDEX] =
-  { status: new StatusMessage(StatusMessage.VARIABLE_VALUE,
-                              'Only first `config.capture.maxStringLength` chars' +
-                              ' were captured.',
-                                false) };
-MESSAGE_TABLE[DATA_LIMIT_MESSAGE_INDEX] =
-  { status: new StatusMessage(StatusMessage.VARIABLE_VALUE,
-                              'Truncating the results because the cap of ' +
-                              '`config.capture.maxDataSize` has been reached.',
-                                false) };
 
 /**
  * Captures the stack and current execution state.
@@ -128,8 +101,32 @@ function StateResolver(execState, expressions, config, v8) {
   this.evaluatedExpressions_ = [];
   this.totalSize_ = 0;
 
-  this.resolvedVariableTable_ = util._extend([], MESSAGE_TABLE);
-  this.rawVariableTable_ = MESSAGE_TABLE.map(function() { return null; });
+  this.messageTable_ = [];
+  this.messageTable_[BUFFER_FULL_MESSAGE_INDEX] =
+    { status: new StatusMessage(StatusMessage.VARIABLE_VALUE,
+                                'Max data size reached', true) };
+  this.messageTable_[NATIVE_PROPERTY_MESSAGE_INDEX] =
+    { status: new StatusMessage(StatusMessage.VARIABLE_VALUE,
+                                'Native properties are not available', true) };
+  this.messageTable_[GETTER_MESSAGE_INDEX] =
+    { status: new StatusMessage(StatusMessage.VARIABLE_VALUE,
+                                'Properties with getters are not available', true) };
+  this.messageTable_[ARG_LOCAL_LIMIT_MESSAGE_INDEX] =
+    { status: new StatusMessage(StatusMessage.VARIABLE_VALUE,
+                                'Locals and arguments are only displayed for the ' +
+                                'top `config.capture.maxExpandFrames=' +
+                                config.capture.maxExpandFrames +
+                                '` stack frames.',
+                                  true) };
+  this.messageTable_[STRING_LIMIT_MESSAGE_INDEX] =
+    { status: new StatusMessage(StatusMessage.VARIABLE_VALUE,
+                                'Only first `config.capture.maxStringLength=' +
+                                config.capture.maxStringLength +
+                                '` chars were captured.',
+                                  false) };
+
+  this.resolvedVariableTable_ = util._extend([], this.messageTable_);
+  this.rawVariableTable_ = this.messageTable_.map(function() { return null; });
 }
 
 
@@ -167,7 +164,7 @@ StateResolver.prototype.capture_ = function() {
   var frames = that.resolveFrames_();
 
   // Now resolve the variables
-  var index = MESSAGE_TABLE.length; // skip the sentinel values
+  var index = this.messageTable_.length; // skip the sentinel values
   var noLimit = that.config_.capture.maxDataSize === 0;
   while (index < that.rawVariableTable_.length && // NOTE: length changes in loop
          (that.totalSize_ < that.config_.capture.maxDataSize || noLimit)) {
@@ -201,12 +198,13 @@ StateResolver.prototype.capture_ = function() {
 StateResolver.prototype.trimVariableTable_ = function(fromIndex, frames) {
   this.resolvedVariableTable_.splice(fromIndex); // remove the remaining entries
 
+  var that = this;
   var processBufferFull = function(variables) {
     variables.forEach(function (variable) {
       if (variable.varTableIndex && variable.varTableIndex >= fromIndex) {
         // make it point to the sentinel 'buffer full' value
         variable.varTableIndex = BUFFER_FULL_MESSAGE_INDEX;
-        variable.status = MESSAGE_TABLE[BUFFER_FULL_MESSAGE_INDEX].status;
+        variable.status = that.messageTable_[BUFFER_FULL_MESSAGE_INDEX].status;
       }
       if (variable.members) {
         processBufferFull(variable.members);
@@ -463,7 +461,7 @@ StateResolver.prototype.resolveVariable_ = function(name, value) {
     var maxLength = this.config_.capture.maxStringLength;
     if (maxLength && maxLength < data.value.length) {
       data.value = data.value.substring(0, maxLength) + '...';
-      data.status = MESSAGE_TABLE[STRING_LIMIT_MESSAGE_INDEX].status;
+      data.status = this.messageTable_[STRING_LIMIT_MESSAGE_INDEX].status;
     }
 
   } else if (value.isFunction()) {
@@ -533,8 +531,9 @@ StateResolver.prototype.resolveMirrorSlow_ = function(mirror) {
     return that.resolveMirrorProperty_(mirror.property(prop));
   });
   if (truncate) {
-    members.push({name: 'Only first `config.capture.maxProperties` ' + 
-                        'properties were captured'});
+    members.push({name: 'Only first `config.capture.maxProperties=' +
+                        this.config_.capture.maxProperties +
+                        '` properties were captured'});
   }
 
   var mirrorVal = mirror.value();
@@ -558,7 +557,9 @@ StateResolver.prototype.resolveMirrorFast_ = function(mirror) {
   }
   var members = properties.map(this.resolveMirrorProperty_.bind(this));
   if (truncate) {
-    members.push({name: 'Only first maxProperties properties were captured'});
+    members.push({name: 'Only first `config.capture.maxProperties=' +
+                        this.config_.capture.maxProperties +
+                        '` properties were captured'});
   }
   return {
     value: mirror.toText(),


### PR DESCRIPTION
Now if a status message referes to a configuration option the
syntax `configname=configvalue` will be used to specify the
configuration option's name as well as its value.

Also deleted the item at the `DATA_LIMIT_MESSAGE_INDEX` index
in the `MESSAGE_TABLE` since it is no longer needed.