### PR TITLE
fix race condition with log points

### DIFF
--- a/lib/v8debugapi.js
+++ b/lib/v8debugapi.js
@@ -207,7 +207,10 @@ module.exports.create = function(logger_, config_, jsFiles_, sourcemapper_) {
           if (logsThisSecond >= config.log.maxLogsPerSecond) {
             listeners[num].enabled = false;
             setTimeout(function() {
-              if (!shouldStop()) {
+              // listeners[num] may have been deleted by `clear` during the
+              // async hop. Make sure it is valid before setting a property on
+              // it.
+              if (!shouldStop() && listeners[num]) {
                 listeners[num].enabled = true;
               }
             }, config.log.logDelaySeconds * 1000);


### PR DESCRIPTION
Cannot assume that listeners[num] would still be valid across an async
hop. It is possible that someone has cleared the log point across the
timeout.