### PR TITLE
Switch from findit to findit2

### DIFF
--- a/lib/scanner.js
+++ b/lib/scanner.js
@@ -19,7 +19,7 @@ var _ = require('lodash');
 var fs = require('fs');
 var path = require('path');
 var crypto = require('crypto');
-var findit = require('findit');
+var findit = require('findit2');
 var split = require('split');
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "acorn": "^4.0.3",
     "async": "^2.1.2",
     "coffee-script": "^1.9.3",
-    "findit": "^2.0.0",
+    "findit2": "^2.2.3",
     "google-auth-library": "^0.9.5",
     "lodash": "^4.12.0",
     "request": "^2.61.0",


### PR DESCRIPTION
https://www.npmjs.com/package/findit2 seems to fix a few open bugs with
findit, which doesn't seem to be maintained anymore. Furthermore, this
fixes the issue that findit was intermittently failing to find all the
files on windows causing the AppVeyor builds to fail.