### PR TITLE
switch to using @google-cloud/common

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 npm-debug.log
 .DS_Store
+.vscode

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "proxyquire": "^1.4.0"
   },
   "dependencies": {
+    "@google-cloud/common": "^0.9.0",
     "@google/cloud-diagnostics-common": "0.3.0",
     "acorn": "^4.0.3",
     "async": "^2.1.2",

--- a/src/agent/debuglet.js
+++ b/src/agent/debuglet.js
@@ -46,7 +46,10 @@ module.exports = Debuglet;
  * @event 'stopped' if the agent stops due to a fatal error after starting
  * @constructor
  */
-function Debuglet(config, logger) {
+function Debuglet(debug, config, logger) {
+  /** @private {Debug} */
+  this.debug_ = debug;
+
   /** @private {object} */
   this.config_ = config || {};
 
@@ -69,7 +72,7 @@ function Debuglet(config, logger) {
   this.logger_ = logger;
 
   /** @private {DebugletApi} */
-  this.debugletApi_ = new DebugletApi(config);
+  this.debugletApi_ = new DebugletApi(this.config_, this.debug_);
 
   /** @private {Object.<string, Breakpoint>} */
   this.activeBreakpointMap_ = {};

--- a/test/auth-request.js
+++ b/test/auth-request.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var request = require('request');
+module.exports = function(options, callback) {
+  request(options, function(err, response, body) {
+    callback(err, body, response);
+  });
+};

--- a/test/e2e/test-breakpoints.js
+++ b/test/e2e/test-breakpoints.js
@@ -250,15 +250,15 @@ function runTest() {
 // and log points.
 if (cluster.isMaster) {
   cluster.setupMaster({ silent: true });
-  var handler = function(m) {
+  var handler = function(a) {
     if (!debuggee) {
       // Cache the needed info from the first worker.
-      debuggee = m.private_.debugletApi_.debuggeeId_;
-      project = m.private_.debugletApi_.project_;
+      debuggee = a[0];
+      project = a[1];
     } else {
       // Make sure all other workers are consistent.
-      assert.equal(debuggee, m.private_.debugletApi_.debuggeeId_);
-      assert.equal(project, m.private_.debugletApi_.project_);
+      assert.equal(debuggee, a[0]);
+      assert.equal(project, a[1]);
     }
   };
   var stdoutHandler = function(chunk) {
@@ -288,12 +288,8 @@ if (cluster.isMaster) {
     assert.ok(api.uid_, 'debuglet provided unique id');
     assert.ok(api.debuggeeId_, 'debuglet has registered');
     // The parent process needs to know the debuggeeId and project.
-    process.send(debug);
+    process.send([api.debuggeeId_, api.project_]);
     setInterval(fib.bind(null, 12), 2000);
   }, 7000);
 
 }
-
-process.on('exit', function() {
-  console.log('worker transcript:', transcript);
-});

--- a/test/e2e/test-log-throttling.js
+++ b/test/e2e/test-log-throttling.js
@@ -181,11 +181,11 @@ function runTest() {
 
 if (cluster.isMaster) {
   cluster.setupMaster({ silent: true });
-  var handler = function(m) {
+  var handler = function(a) {
     // Cache the needed info from the first worker.
     if (!debuggee) {
-      debuggee = m.private_.debugletApi_.debuggeeId_;
-      project = m.private_.debugletApi_.project_;
+      debuggee = a[0];
+      project = a[1];
     }
   };
   var stdoutHandler = function(chunk) {
@@ -216,7 +216,7 @@ if (cluster.isMaster) {
     var api = debuglet.debugletApi_;
     assert.ok(api.uid_, 'debuglet provided unique id');
     assert.ok(api.debuggeeId_, 'debuglet has registered');
-    process.send(debug);
+    process.send([api.debuggeeId_, api.project_]);
     setInterval(fib.bind(null, 12), 500);
   }, 7000);
 }

--- a/test/standalone/test-debuglet.js
+++ b/test/standalone/test-debuglet.js
@@ -16,7 +16,7 @@
 'use strict';
 
 var assert = require('assert');
-var request = require('request');
+var request = require('../auth-request.js');
 var logger = require('@google/cloud-diagnostics-common').logger;
 var config = require('../../src/config.js').debug;
 var Debuglet = require('../../src/agent/debuglet.js');
@@ -29,6 +29,9 @@ var BPS_PATH = '/v2/controller/debuggees/' + DEBUGGEE_ID + '/breakpoints';
 var nock = require('nock');
 nock.disableNetConnect();
 
+// Disable error logging during the tests.
+config.logLevel = 0;
+
 var debuglet;
 var bp = {
   id: 'test',
@@ -40,12 +43,15 @@ var errorBp = {
   action: 'FOO',
   location: { path: 'fixtures/foo.js', line: 2 }
 };
+var fakeDebug = {
+  request: request
+};
 
 describe(__filename, function(){
   beforeEach(function() {
     process.env.GCLOUD_PROJECT = 0;
     debuglet = new Debuglet(
-      config, logger.create(config.logLevel, '@google/cloud-debug'));
+      fakeDebug, config, logger.create(config.logLevel, '@google/cloud-debug'));
     debuglet.once('started', function() {
       debuglet.debugletApi_.request_ = request; // Avoid authing.
     });
@@ -236,7 +242,7 @@ describe(__filename, function(){
     config.breakpointExpirationSec = 1;
     this.timeout(6000);
     var debuglet = new Debuglet(
-      config, logger.create(config.logLevel, '@google/cloud-debug'));
+      fakeDebug, config, logger.create(config.logLevel, '@google/cloud-debug'));
 
     var scope = nock(API)
       .post(REGISTER_PATH)
@@ -288,7 +294,7 @@ describe(__filename, function(){
     config.breakpointUpdateIntervalSec = 1;
     this.timeout(6000);
     var debuglet = new Debuglet(
-      config, logger.create(config.logLevel, '@google/cloud-debug'));
+      fakeDebug, config, logger.create(config.logLevel, '@google/cloud-debug'));
 
     var scope = nock(API)
       .post(REGISTER_PATH)


### PR DESCRIPTION
This PR starts using the authorized / retry request flow from the
@google-cloud/common library. From an operational perspective This
shouldn't change behaviour significantly – although there are small
differences in how the new library does retries or how it prioritizes
different sources of the projectId & credentials (environment vs.
metadata vs. config).