### PR TITLE
Change argument order in updateBreakpoint

### DIFF
--- a/src/agent/debuglet.js
+++ b/src/agent/debuglet.js
@@ -100,7 +100,7 @@ Debuglet.prototype.normalizeConfig_ = function(config) {
   config = extend({}, defaultConfig, config);
 
   if (config.keyFilename || config.credentials || config.projectId) {
-    throw new Error('keyFilename, projectId or credentials should be provided' + 
+    throw new Error('keyFilename, projectId or credentials should be provided' +
                     ' to the Debug module constructor rather than startAgent');
   }
 
@@ -151,7 +151,7 @@ Debuglet.prototype.start = function() {
           that.emit('initError', err);
           return;
         }
-        
+
         that.v8debug_ = v8debugapi.create(that.logger_, that.config_, jsStats, mapper);
 
         id = id || hash;
@@ -365,7 +365,7 @@ Debuglet.prototype.scheduleBreakpointFetch_ = function(seconds) {
                            err);
         that.fetcherActive_ = false;
         // We back-off from fetching breakpoints, and try to register again
-        // after a while. Successful registration will restart the breakpoint 
+        // after a while. Successful registration will restart the breakpoint
         // fetcher.
         that.scheduleRegistration_(
             that.config_.internal.registerDelayOnFetcherErrorSec);
@@ -538,7 +538,7 @@ Debuglet.prototype.completeBreakpoint_ = function(breakpoint) {
 
   that.logger_.info('\tupdating breakpoint data on server', breakpoint.id);
   that.debugletApi_.updateBreakpoint(
-      breakpoint, that.debuggee_, function(err /*, body*/) {
+      that.debuggee_, breakpoint, function(err /*, body*/) {
         if (err) {
           that.logger_.error('Unable to complete breakpoint on server', err);
         } else {
@@ -557,7 +557,7 @@ Debuglet.prototype.rejectBreakpoint_ = function(breakpoint) {
   var that = this;
 
   that.debugletApi_.updateBreakpoint(
-      breakpoint, that.debuggee_, function(err /*, body*/) {
+      that.debuggee_, breakpoint, function(err /*, body*/) {
         if (err) {
           that.logger_.error('Unable to complete breakpoint on server', err);
         }

--- a/src/controller.js
+++ b/src/controller.js
@@ -45,7 +45,7 @@ util.inherits(Controller, common.ServiceObject);
 
 /**
  * Register to the API (implementation)
- * 
+ *
  * @param {!function(?Error,Object=)} callback
  * @private
  */
@@ -112,10 +112,11 @@ Controller.prototype.listBreakpoints = function(debuggee, callback) {
 
 /**
  * Update the server about breakpoint state
+ * @param {!Debuggee} debuggee
  * @param {!Breakpoint} breakpoint
  * @param {!Function} callback accepting (err, body)
  */
-Controller.prototype.updateBreakpoint = function(breakpoint, debuggee, callback) {
+Controller.prototype.updateBreakpoint = function(debuggee, breakpoint, callback) {
   assert(debuggee.id, 'should have a registered debuggee');
 
   breakpoint.action = 'capture';

--- a/test/test-controller.js
+++ b/test/test-controller.js
@@ -231,7 +231,7 @@ describe('Controller API', function() {
         .reply(200, { kind: 'debugletcontroller#updateActiveBreakpointResponse'});
       var debuggee = { id: 'fake-debuggee' };
       var controller = new Controller(fakeDebug);
-      controller.updateBreakpoint(breakpoint, debuggee,
+      controller.updateBreakpoint(debuggee, breakpoint,
         function(err, result) {
           assert(!err, 'not expecting an error');
           assert.equal(result.kind, 'debugletcontroller#updateActiveBreakpointResponse');


### PR DESCRIPTION
I'm proposing to change the argument order here so that debuggee is first - I believe this makes more sense because the debuggee comes before the breakpoint in the method path [as seen here](https://cloud.google.com/debugger/api/reference/rest/v2/controller.debuggees.breakpoints/update).