### PR TITLE
controller API requires Debuggee.description

### DIFF
--- a/src/debuggee.js
+++ b/src/debuggee.js
@@ -29,8 +29,8 @@ var _ = require('lodash');
  *     project. Any string that identifies the application within the project
  *     can be used. Including environment and version or build IDs is
  *     recommended.
- * @param {?string} properties.description - A user specified string identifyin
- *     this debuggable instance (default: none)
+ * @param {string} properties.description - A user specified string identifying
+ *     this debuggable instance.
  * @param {?string} properties.agentVersion - version ID of the agent. (default:
  *     the version of this module)
  * @param {?object} labels - a set of custom properties about the debuggee that
@@ -55,14 +55,15 @@ function Debuggee(properties) {
   if (!_.isString(properties.uniquifier)) {
     throw new Error('properties.uniquifier must be a string');
   }
+  if (!_.isString(properties.description)) {
+    throw new Error('properties.description must be a string');
+  }
 
   this.project = properties.project;
   this.uniquifier = properties.uniquifier;
+  this.description = properties.description;
   this.agentVersion =
-      properties.agentVersion || (pjson.name + '/default/v' + pjson.version);
-  if (properties.description) {
-    this.description = properties.description;
-  }
+      properties.agentVersion || (pjson.name + '/client/v' + pjson.version);
   if (properties.labels) {
     this.labels = properties.labels;
   }

--- a/system-test/test-controller.js
+++ b/system-test/test-controller.js
@@ -38,7 +38,8 @@ describe('Controller', function() {
     var debuggee =
         new Debuggee({
           project: process.env.GCLOUD_PROJECT, 
-          uniquifier: 'test-uid-' + Date.now()
+          uniquifier: 'test-uid-' + Date.now(),
+          description: 'this is a system test'
         });
 
     controller.register(debuggee, function(err, body) {
@@ -55,7 +56,8 @@ describe('Controller', function() {
     var debuggee =
         new Debuggee({
           project: process.env.GCLOUD_PROJECT, 
-          uniquifier: 'test-uid-' + Date.now()
+          uniquifier: 'test-uid-' + Date.now(),
+          description: 'this is a system test'
         });
     controller.register(debuggee, function(err, body) {
       assert.ifError(err, 'should be able to register successfully');

--- a/test/test-controller.js
+++ b/test/test-controller.js
@@ -54,8 +54,11 @@ describe('Controller API', function() {
               .post(api + '/debuggees/register')
               .reply(200,
                      {debuggee: {id: 'fake-debuggee'}, activePeriodSec: 600});
-      var debuggee =
-          new Debuggee({project: 'fake-project', uniquifier: 'fake-id'});
+      var debuggee = new Debuggee({
+        project: 'fake-project',
+        uniquifier: 'fake-id',
+        description: 'unit test'
+      });
       var controller = new Controller(fakeDebug);
       controller.register(debuggee, function(err, result) {
         assert(!err, 'not expecting an error');
@@ -77,8 +80,11 @@ describe('Controller API', function() {
               .post(api + '/debuggees/register')
               .reply(200,
                      {debuggee: {id: 'fake-debuggee'}, activePeriodSec: 600});
-      var debuggee =
-          new Debuggee({project: 'fake-project', uniquifier: 'fake-id'});
+      var debuggee = new Debuggee({
+        project: 'fake-project',
+        uniquifier: 'fake-id',
+        description: 'unit test'
+      });
       controller.register(debuggee, function(err, result) {
         assert(!err, 'not expecting an error');
         assert.equal(result.debuggee.id, 'fake-debuggee');
@@ -99,8 +105,11 @@ describe('Controller API', function() {
                       },
                       activePeriodSec: 600,
                     });
-      var debuggee =
-          new Debuggee({project: 'fake-project', uniquifier: 'fake-id'});
+      var debuggee = new Debuggee({
+        project: 'fake-project',
+        uniquifier: 'fake-id',
+        description: 'unit test'
+      });
       var controller = new Controller(fakeDebug);
       controller.register(debuggee, function(err/*, result*/) {
         assert(err, 'expected an error');
@@ -121,8 +130,11 @@ describe('Controller API', function() {
           debuggee: { id: 'fake-debuggee' },
           activePeriodSec: 600
         });
-      var debuggee =
-          new Debuggee({project: 'fake-project', uniquifier: 'fake-id'});
+      var debuggee = new Debuggee({
+        project: 'fake-project',
+        uniquifier: 'fake-id',
+        description: 'unit test'
+      });
       var controller = new Controller(fakeDebug);
       controller.register(debuggee, function(err/*, result*/) {
         assert.ifError(err);

--- a/test/test-debuggee.js
+++ b/test/test-debuggee.js
@@ -21,12 +21,14 @@ var Debuggee = require('../src/debuggee.js');
 describe('Debuggee', function() {
 
   it('should create a Debuggee instance on valid input', function() {
-    var debuggee = new Debuggee({project:'project', uniquifier: 'uid'});
+    var debuggee = new Debuggee(
+        {project: 'project', uniquifier: 'uid', description: 'unit test'});
     assert.ok(debuggee instanceof Debuggee);
   });
 
   it('should create a Debuggee on a call without new', function() {
-    var debuggee = new Debuggee({project:'project', uniquifier: 'uid'});
+    var debuggee = new Debuggee(
+        {project: 'project', uniquifier: 'uid', description: 'unit test'});
     assert.ok(debuggee instanceof Debuggee);
   });
 
@@ -37,6 +39,9 @@ describe('Debuggee', function() {
     assert.throws(function() { new Debuggee({project: 'test'}); });
     assert.throws(function() {
       new Debuggee({project: 'test', uniquifier: null});
+      assert.throws(function() {
+        new Debuggee({project: 'test', uniquifier: 'uid'});
+      });
     });
   });
 


### PR DESCRIPTION
Make this a mandatory property for Debuggee. This doesn't affect the agent – as it always passes in a description – but the system tests were failing.