### PR TITLE
Remove duplicate isDisabled logic from controller

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -64,8 +64,6 @@ Controller.prototype.register = function(debuggee, callback) {
           new Error('unable to register, statusCode ' + response.statusCode));
     } else if (!body.debuggee) {
       callback(new Error('invalid response body from server'));
-    } else if (body.debuggee.isDisabled) {
-      callback('Debuggee is disabled on server');
     } else {
       debuggee.id = body.debuggee.id;
       callback(null, body);

--- a/test/test-controller.js
+++ b/test/test-controller.js
@@ -95,28 +95,28 @@ describe('Controller API', function() {
       });
     });
 
-    it('should return error when debuggee is disabled', function(done) {
-      var scope = nock(url)
-                    .post(api + '/debuggees/register')
-                    .reply(200, {
-                      debuggee: {
-                        id: 'fake-debuggee',
-                        isDisabled: true
-                      },
-                      activePeriodSec: 600,
-                    });
-      var debuggee = new Debuggee({
-        project: 'fake-project',
-        uniquifier: 'fake-id',
-        description: 'unit test'
-      });
-      var controller = new Controller(fakeDebug);
-      controller.register(debuggee, function(err/*, result*/) {
-        assert(err, 'expected an error');
-        scope.done();
-        done();
-      });
-    });
+    it('should not return an error when the debuggee isDisabled',
+       function(done) {
+         var scope = nock(url)
+                         .post(api + '/debuggees/register')
+                         .reply(200, {
+                           debuggee: {id: 'fake-debuggee', isDisabled: true},
+                           activePeriodSec: 600,
+                         });
+         var debuggee = new Debuggee({
+           project: 'fake-project',
+           uniquifier: 'fake-id',
+           description: 'unit test'
+         });
+         var controller = new Controller(fakeDebug);
+         controller.register(debuggee, function(err, result) {
+           assert.ifError(err, 'not expected an error');
+           assert.equal(result.debuggee.id, 'fake-debuggee');
+           assert.ok(result.debuggee.isDisabled);
+           scope.done();
+           done();
+         });
+       });
 
   });
 


### PR DESCRIPTION
The debuglet also has the same isDisabled check. Arguably the
controller shouldn't be doing this check at all because we do get a
valid debuggee.id back from the service and we should faithfully
report that to the client of the Controller interface. Business logic
to deal with a disabled debuggee belongs in the agent.