### PR TITLE
Make all tests runnable together

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,6 @@ install:
 test_script:
   # run tests
   - ps: node_modules/.bin/mocha test --timeout 4000 --R
-  - ps: ForEach ($test in Get-ChildItem test/standalone/test-*.js) { node_modules/.bin/mocha $test --timeout 4000 --R; if ($lastexitcode -ne 0) { exit 1 } }
 
 # Don't actually build using MSBuild
 build: off

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -31,10 +31,6 @@ function run {
 
 # Run test/coverage
 run test
-for test in test/standalone/test-*.js ;
-do
-  run "${test}"
-done
 
 # Conditionally publish coverage
 if [ "$cover" ]; then

--- a/src/agent/v8debugapi.js
+++ b/src/agent/v8debugapi.js
@@ -59,7 +59,7 @@ var formatInterval = function(msg, interval) {
 
 var singleton;
 module.exports.create = function(logger_, config_, jsFiles_, sourcemapper_) {
-  if (singleton) {
+  if (singleton && !config_.force) {
     return singleton;
   }
 

--- a/src/agent/v8debugapi.js
+++ b/src/agent/v8debugapi.js
@@ -59,7 +59,7 @@ var formatInterval = function(msg, interval) {
 
 var singleton;
 module.exports.create = function(logger_, config_, jsFiles_, sourcemapper_) {
-  if (singleton && !config_.force) {
+  if (singleton && !config_.force_) {
     return singleton;
   }
 

--- a/src/agent/v8debugapi.js
+++ b/src/agent/v8debugapi.js
@@ -59,7 +59,7 @@ var formatInterval = function(msg, interval) {
 
 var singleton;
 module.exports.create = function(logger_, config_, jsFiles_, sourcemapper_) {
-  if (singleton && !config_.force_) {
+  if (singleton && !config_.forceNewAgent_) {
     return singleton;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -83,8 +83,8 @@ var debuglet;
  * debug.startAgent();
  */
 Debug.prototype.startAgent = function(config) {
-  // config.force_ is for testing purposes only.
-  if (debuglet && !config.force_) {
+  // config.forceNewAgent_ is for testing purposes only.
+  if (debuglet && !config.forceNewAgent_) {
     throw new Error('Debug Agent has already been started');
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,8 @@ var debuglet;
  * debug.startAgent();
  */
 Debug.prototype.startAgent = function(config) {
-  if (debuglet) {
+  // config.force_ is for testing purposes only.
+  if (debuglet && !config.force_) {
     throw new Error('Debug Agent has already been started');
   }
 

--- a/test/test-debuglet.js
+++ b/test/test-debuglet.js
@@ -254,7 +254,10 @@ describe('Debuglet', function() {
     it('should error if a package.json doesn\'t exist', function(done) {
       var debug = require('..')(
           {projectId: 'fake-project', credentials: fakeCredentials});
-      var config = extend({}, defaultConfig, {workingDirectory: __dirname});
+      var config = extend({}, defaultConfig, {
+        workingDirectory: __dirname,
+        force_: true
+      });
       var debuglet = new Debuglet(debug, config);
 
       debuglet.once('initError', function(err) {
@@ -493,7 +496,10 @@ describe('Debuglet', function() {
     it('should expire stale breakpoints', function(done) {
       var debug = require('..')(
           {projectId: 'fake-project', credentials: fakeCredentials});
-      var config = extend({}, defaultConfig, {breakpointExpirationSec: 1});
+      var config = extend({}, defaultConfig, {
+        breakpointExpirationSec: 1,
+        force_: true
+      });
       this.timeout(6000);
 
       var scope = nock(API)
@@ -542,7 +548,8 @@ describe('Debuglet', function() {
           {projectId: 'fake-project', credentials: fakeCredentials});
       var config = extend({}, defaultConfig, {
         breakpointExpirationSec: 1,
-        breakpointUpdateIntervalSec: 1
+        breakpointUpdateIntervalSec: 1,
+        force_: true
       });
       this.timeout(6000);
 

--- a/test/test-debuglet.js
+++ b/test/test-debuglet.js
@@ -256,7 +256,7 @@ describe('Debuglet', function() {
           {projectId: 'fake-project', credentials: fakeCredentials});
       var config = extend({}, defaultConfig, {
         workingDirectory: __dirname,
-        force_: true
+        forceNewAgent_: true
       });
       var debuglet = new Debuglet(debug, config);
 
@@ -498,7 +498,7 @@ describe('Debuglet', function() {
           {projectId: 'fake-project', credentials: fakeCredentials});
       var config = extend({}, defaultConfig, {
         breakpointExpirationSec: 1,
-        force_: true
+        forceNewAgent_: true
       });
       this.timeout(6000);
 
@@ -549,7 +549,7 @@ describe('Debuglet', function() {
       var config = extend({}, defaultConfig, {
         breakpointExpirationSec: 1,
         breakpointUpdateIntervalSec: 1,
-        force_: true
+        forceNewAgent_: true
       });
       this.timeout(6000);
 

--- a/test/test-duplicate-expressions.js
+++ b/test/test-duplicate-expressions.js
@@ -28,11 +28,6 @@ var breakpointInFoo = {
 
 var assert = require('assert');
 var extend = require('extend');
-var v8debugapi = require('../../src/agent/v8debugapi.js');
-var common = require('@google-cloud/common');
-var defaultConfig = require('../../src/agent/config.js');
-var SourceMapper = require('../../src/agent/sourcemapper.js');
-var scanner = require('../../src/agent/scanner.js');
 var v8debugapi = require('../src/agent/v8debugapi.js');
 var common = require('@google-cloud/common');
 var defaultConfig = require('../src/agent/config.js');
@@ -50,7 +45,8 @@ function stateIsClean(api) {
 
 describe('v8debugapi', function() {
   var config = extend({}, defaultConfig, {
-    workingDirectory: path.join(process.cwd(), 'test')
+    workingDirectory: path.join(process.cwd(), 'test'),
+    force_: true
   });
   var logger = common.logger({ logLevel: config.logLevel });
   var api = null;

--- a/test/test-duplicate-expressions.js
+++ b/test/test-duplicate-expressions.js
@@ -33,6 +33,11 @@ var common = require('@google-cloud/common');
 var defaultConfig = require('../../src/agent/config.js');
 var SourceMapper = require('../../src/agent/sourcemapper.js');
 var scanner = require('../../src/agent/scanner.js');
+var v8debugapi = require('../src/agent/v8debugapi.js');
+var common = require('@google-cloud/common');
+var defaultConfig = require('../src/agent/config.js');
+var SourceMapper = require('../src/agent/sourcemapper.js');
+var scanner = require('../src/agent/scanner.js');
 var path = require('path');
 
 function stateIsClean(api) {
@@ -45,7 +50,7 @@ function stateIsClean(api) {
 
 describe('v8debugapi', function() {
   var config = extend({}, defaultConfig, {
-    workingDirectory: path.join(process.cwd(), 'test', 'standalone')
+    workingDirectory: path.join(process.cwd(), 'test')
   });
   var logger = common.logger({ logLevel: config.logLevel });
   var api = null;

--- a/test/test-duplicate-expressions.js
+++ b/test/test-duplicate-expressions.js
@@ -46,7 +46,7 @@ function stateIsClean(api) {
 describe('v8debugapi', function() {
   var config = extend({}, defaultConfig, {
     workingDirectory: path.join(process.cwd(), 'test'),
-    force_: true
+    forceNewAgent_: true
   });
   var logger = common.logger({ logLevel: config.logLevel });
   var api = null;

--- a/test/test-duplicate-nested-expressions.js
+++ b/test/test-duplicate-nested-expressions.js
@@ -44,7 +44,8 @@ function stateIsClean(api) {
 
 describe('v8debugapi', function() {
   var config = extend({}, defaultConfig, {
-    workingDirectory: path.join(process.cwd(), 'test')
+    workingDirectory: path.join(process.cwd(), 'test'),
+    force_: true
   });
   var logger = common.logger({ logLevel: config.logLevel });
   var api = null;

--- a/test/test-duplicate-nested-expressions.js
+++ b/test/test-duplicate-nested-expressions.js
@@ -26,11 +26,11 @@
 
 var assert = require('assert');
 var extend = require('extend');
-var v8debugapi = require('../../src/agent/v8debugapi.js');
+var v8debugapi = require('../src/agent/v8debugapi.js');
 var common = require('@google-cloud/common');
-var defaultConfig = require('../../src/agent/config.js');
-var SourceMapper = require('../../src/agent/sourcemapper.js');
-var scanner = require('../../src/agent/scanner.js');
+var defaultConfig = require('../src/agent/config.js');
+var SourceMapper = require('../src/agent/sourcemapper.js');
+var scanner = require('../src/agent/scanner.js');
 var path = require('path');
 var semver = require('semver');
 
@@ -44,7 +44,7 @@ function stateIsClean(api) {
 
 describe('v8debugapi', function() {
   var config = extend({}, defaultConfig, {
-    workingDirectory: path.join(process.cwd(), 'test', 'standalone')
+    workingDirectory: path.join(process.cwd(), 'test')
   });
   var logger = common.logger({ logLevel: config.logLevel });
   var api = null;

--- a/test/test-duplicate-nested-expressions.js
+++ b/test/test-duplicate-nested-expressions.js
@@ -45,7 +45,7 @@ function stateIsClean(api) {
 describe('v8debugapi', function() {
   var config = extend({}, defaultConfig, {
     workingDirectory: path.join(process.cwd(), 'test'),
-    force_: true
+    forceNewAgent_: true
   });
   var logger = common.logger({ logLevel: config.logLevel });
   var api = null;

--- a/test/test-env-relative-repository-path.js
+++ b/test/test-env-relative-repository-path.js
@@ -21,9 +21,9 @@ var path = require('path');
 process.env.GCLOUD_PROJECT = 0;
 
 var assert = require('assert');
-var agent = require('../..')();
+var agent = require('..')();
 var api;
-var h = require('../fixtures/a/hello.js');
+var h = require('./fixtures/a/hello.js');
 
 describe('repository relative paths', function() {
 

--- a/test/test-fat-arrow.js
+++ b/test/test-fat-arrow.js
@@ -38,7 +38,7 @@ function stateIsClean(api) {
 describe('v8debugapi', function() {
   var config = extend({}, defaultConfig, {
     workingDirectory: path.join(process.cwd(), 'test'),
-    force_: true
+    forceNewAgent_: true
   });
   var logger = common.logger({ logLevel: config.logLevel });
   var api = null;

--- a/test/test-fat-arrow.js
+++ b/test/test-fat-arrow.js
@@ -37,7 +37,8 @@ function stateIsClean(api) {
 
 describe('v8debugapi', function() {
   var config = extend({}, defaultConfig, {
-    workingDirectory: path.join(process.cwd(), 'test')
+    workingDirectory: path.join(process.cwd(), 'test'),
+    force_: true
   });
   var logger = common.logger({ logLevel: config.logLevel });
   var api = null;

--- a/test/test-fat-arrow.js
+++ b/test/test-fat-arrow.js
@@ -17,11 +17,11 @@
 
 var assert = require('assert');
 var extend = require('extend');
-var v8debugapi = require('../../src/agent/v8debugapi.js');
+var v8debugapi = require('../src/agent/v8debugapi.js');
 var common = require('@google-cloud/common');
-var defaultConfig = require('../../src/agent/config.js');
-var SourceMapper = require('../../src/agent/sourcemapper.js');
-var scanner = require('../../src/agent/scanner.js');
+var defaultConfig = require('../src/agent/config.js');
+var SourceMapper = require('../src/agent/sourcemapper.js');
+var scanner = require('../src/agent/scanner.js');
 var path = require('path');
 var semver = require('semver');
 
@@ -50,7 +50,7 @@ describe('v8debugapi', function() {
       this.skip();
       return;
     }
-    foo = require('../fixtures/fat-arrow.js');
+    foo = require('./fixtures/fat-arrow.js');
   });
   beforeEach(function(done) {
     if (!api) {

--- a/test/test-max-data-size.js
+++ b/test/test-max-data-size.js
@@ -37,7 +37,7 @@ var breakpointInFoo = {
 
 describe('maxDataSize', function() {
   var config = extend({}, defaultConfig, {
-    force_: true
+    forceNewAgent_: true
   });
 
   before(function(done) {

--- a/test/test-max-data-size.js
+++ b/test/test-max-data-size.js
@@ -36,7 +36,9 @@ var breakpointInFoo = {
 };
 
 describe('maxDataSize', function() {
-  var config = extend({}, defaultConfig);
+  var config = extend({}, defaultConfig, {
+    force_: true
+  });
 
   before(function(done) {
     if (!api) {

--- a/test/test-max-data-size.js
+++ b/test/test-max-data-size.js
@@ -24,10 +24,10 @@ process.env.GCLOUD_DIAGNOSTICS_CONFIG = 'test/fixtures/test-config.js';
 var assert = require('assert');
 var extend = require('extend');
 var common = require('@google-cloud/common');
-var v8debugapi = require('../../src/agent/v8debugapi.js');
-var SourceMapper = require('../../src/agent/sourcemapper.js');
-var scanner = require('../../src/agent/scanner.js');
-var defaultConfig = require('../../src/agent/config.js');
+var v8debugapi = require('../src/agent/v8debugapi.js');
+var SourceMapper = require('../src/agent/sourcemapper.js');
+var scanner = require('../src/agent/scanner.js');
+var defaultConfig = require('../src/agent/config.js');
 var api;
 
 var breakpointInFoo = {

--- a/test/test-module.js
+++ b/test/test-module.js
@@ -28,7 +28,7 @@ describe('Debug module', function() {
 
   before(function(done) {
     debug = require('..')({ projectId: '0' });
-    debug.startAgent();
+    debug.startAgent({ force_: true });
 
     debug.private_.on('started', function() {
       debug.private_.stop();

--- a/test/test-module.js
+++ b/test/test-module.js
@@ -28,7 +28,7 @@ describe('Debug module', function() {
 
   before(function(done) {
     debug = require('..')({ projectId: '0' });
-    debug.startAgent({ force_: true });
+    debug.startAgent({ forceNewAgent_: true });
 
     debug.private_.on('started', function() {
       debug.private_.stop();

--- a/test/test-this-context.js
+++ b/test/test-this-context.js
@@ -1,12 +1,12 @@
-/*1* KEEP THIS CODE AT THE TOP TO AVOID LINE NUMBER CHANGES */ /* jshint shadow:true */
+/*1* KEEP THIS CODE AT THE TOP TO AVOID LINE NUMBER CHANGES */
 /*2*/'use strict';
-/*3*/function foo() {
-/*4*/ try {
-/*5*/   throw new Error('A test');
-/*6*/ } catch (e) {
-/*7*/   var e = 2;
-/*8*/   return e;
-/*9*/ }
+/*3*/function foo(b) {/* jshint validthis: true */
+/*4*/ this.a = 10;
+/*5*/ this.a += b;
+/*6*/ return this;
+/*7*/}
+/*8*/function bar(j) {
+/*9*/ return j;
 /*10*/}
 /**
  * Copyright 2015 Google Inc. All Rights Reserved.
@@ -26,11 +26,11 @@
 
 var assert = require('assert');
 var extend = require('extend');
-var v8debugapi = require('../../src/agent/v8debugapi.js');
+var v8debugapi = require('../src/agent/v8debugapi.js');
 var common = require('@google-cloud/common');
-var defaultConfig = require('../../src/agent/config.js');
-var SourceMapper = require('../../src/agent/sourcemapper.js');
-var scanner = require('../../src/agent/scanner.js');
+var defaultConfig = require('../src/agent/config.js');
+var SourceMapper = require('../src/agent/sourcemapper.js');
+var scanner = require('../src/agent/scanner.js');
 var path = require('path');
 var semver = require('semver');
 
@@ -44,7 +44,7 @@ function stateIsClean(api) {
 
 describe('v8debugapi', function() {
   var config = extend({}, defaultConfig, {
-    workingDirectory: path.join(process.cwd(), 'test', 'standalone')
+    workingDirectory: path.join(process.cwd(), 'test')
   });
   var logger = common.logger({ logLevel: config.logLevel });
   var api = null;
@@ -71,11 +71,12 @@ describe('v8debugapi', function() {
     }
   });
   afterEach(function() { assert(stateIsClean(api)); });
-  it('Should read e as the caught error', function(done) {
-    var brk = {
-      id: 'fake-id-123',
-      location: { path: 'test-try-catch.js', line: 7 }
-    };
+  it('Should be able to read the argument and the context', function(done) {
+      var brk = {
+        id: 'fake-id-123',
+        location: { path: 'test-this-context.js', line: 5 }
+      };
+      var ctxMembers;
     api.set(brk, function(err) {
       assert.ifError(err);
       api.wait(brk, function(err) {
@@ -83,31 +84,36 @@ describe('v8debugapi', function() {
         var frame = brk.stackFrames[0];
         var args = frame.arguments;
         var locals = frame.locals;
-        assert.equal(locals.length, 1, 'There should be one local');
+        ctxMembers = brk.variableTable.slice(brk.variableTable.length-1)[0]
+          .members;
+        assert.deepEqual(ctxMembers.length, 1, 
+          'There should be one member in the context variable value');
+        assert.deepEqual(ctxMembers[0], {name: 'a', value: '10'});
         if (semver.satisfies(process.version, '<1.6')) {
-          // Try/Catch scope-walking does not work on 0.12
-          assert.deepEqual(
-            locals[0],
-            {name: 'e', value: 'undefined'}
-          );
+            assert.equal(args.length, 1, 'There should be one argument');
+            assert.equal(locals.length, 1, 'There should be one local');
+            assert.deepEqual(
+              args[0],
+              {name: 'b', value: '1'}
+   	   	    );
+            assert.deepEqual(locals[0].name, 'context');
         } else {
           assert.equal(args.length, 0, 'There should be zero arguments');
-          var e = locals[0];
-          assert(e.name === 'e');
-          assert(Number.isInteger(e.varTableIndex));
+          assert.equal(locals.length, 2, 'There should be two locals');
+          assert.deepEqual(locals[0], {name: 'b', value: '1'});
+          assert.deepEqual(locals[1].name, 'context');
         }
-        assert.equal(args.length, 0, 'There should be zero arguments');     
         api.clear(brk);
         done();
       });
-      process.nextTick(foo.bind(null, 'test'));
+      process.nextTick(foo.bind({}, 1));
     });
   });
-  it('Should read e as the local error', function(done) {
-    var brk = {
-      id: 'fake-id-123',
-      location: { path: 'test-try-catch.js', line: 8 }
-    };
+  it('Should be able to read the argument and deny the context', function(done) {
+      var brk = {
+        id: 'fake-id-123',
+        location: { path: 'test-this-context.js', line: 9 }
+      };
     api.set(brk, function(err) {
       assert.ifError(err);
       api.wait(brk, function(err) {
@@ -116,24 +122,21 @@ describe('v8debugapi', function() {
         var args = frame.arguments;
         var locals = frame.locals;
         if (semver.satisfies(process.version, '<1.6')) {
-          // Try/Catch scope-walking does not work on 0.12
-          assert.deepEqual(
-            locals[0],
-            {name: 'e', value: 'undefined'}
-          );
+            assert.equal(args.length, 1, 'There should be one argument');
+            assert.equal(locals.length, 0);
+             assert.deepEqual(
+              args[0],
+              {name: 'j', value: '1'}
+   	   	    );
         } else {
           assert.equal(args.length, 0, 'There should be zero arguments');
           assert.equal(locals.length, 1, 'There should be one local');
-          assert.deepEqual(
-            locals[0],
-            {name: 'e', value: '2'}
-          );
-          assert.equal(args.length, 0, 'There should be zero arguments');
+          assert.deepEqual(locals[0], {name: 'j', value: '1'});
         }
         api.clear(brk);
         done();
       });
-      process.nextTick(foo.bind(null, 'test'));
+      process.nextTick(bar.bind(null, 1));
     });
   });
 });

--- a/test/test-this-context.js
+++ b/test/test-this-context.js
@@ -44,7 +44,8 @@ function stateIsClean(api) {
 
 describe('v8debugapi', function() {
   var config = extend({}, defaultConfig, {
-    workingDirectory: path.join(process.cwd(), 'test')
+    workingDirectory: path.join(process.cwd(), 'test'),
+    force_: true
   });
   var logger = common.logger({ logLevel: config.logLevel });
   var api = null;

--- a/test/test-this-context.js
+++ b/test/test-this-context.js
@@ -45,7 +45,7 @@ function stateIsClean(api) {
 describe('v8debugapi', function() {
   var config = extend({}, defaultConfig, {
     workingDirectory: path.join(process.cwd(), 'test'),
-    force_: true
+    forceNewAgent_: true
   });
   var logger = common.logger({ logLevel: config.logLevel });
   var api = null;

--- a/test/test-try-catch.js
+++ b/test/test-try-catch.js
@@ -44,7 +44,8 @@ function stateIsClean(api) {
 
 describe('v8debugapi', function() {
   var config = extend({}, defaultConfig, {
-    workingDirectory: path.join(process.cwd(), 'test')
+    workingDirectory: path.join(process.cwd(), 'test'),
+    force_: true
   });
   var logger = common.logger({ logLevel: config.logLevel });
   var api = null;

--- a/test/test-try-catch.js
+++ b/test/test-try-catch.js
@@ -1,12 +1,12 @@
-/*1* KEEP THIS CODE AT THE TOP TO AVOID LINE NUMBER CHANGES */
+/*1* KEEP THIS CODE AT THE TOP TO AVOID LINE NUMBER CHANGES */ /* jshint shadow:true */
 /*2*/'use strict';
-/*3*/function foo(b) {/* jshint validthis: true */
-/*4*/ this.a = 10;
-/*5*/ this.a += b;
-/*6*/ return this;
-/*7*/}
-/*8*/function bar(j) {
-/*9*/ return j;
+/*3*/function foo() {
+/*4*/ try {
+/*5*/   throw new Error('A test');
+/*6*/ } catch (e) {
+/*7*/   var e = 2;
+/*8*/   return e;
+/*9*/ }
 /*10*/}
 /**
  * Copyright 2015 Google Inc. All Rights Reserved.
@@ -26,11 +26,11 @@
 
 var assert = require('assert');
 var extend = require('extend');
-var v8debugapi = require('../../src/agent/v8debugapi.js');
+var v8debugapi = require('../src/agent/v8debugapi.js');
 var common = require('@google-cloud/common');
-var defaultConfig = require('../../src/agent/config.js');
-var SourceMapper = require('../../src/agent/sourcemapper.js');
-var scanner = require('../../src/agent/scanner.js');
+var defaultConfig = require('../src/agent/config.js');
+var SourceMapper = require('../src/agent/sourcemapper.js');
+var scanner = require('../src/agent/scanner.js');
 var path = require('path');
 var semver = require('semver');
 
@@ -44,7 +44,7 @@ function stateIsClean(api) {
 
 describe('v8debugapi', function() {
   var config = extend({}, defaultConfig, {
-    workingDirectory: path.join(process.cwd(), 'test', 'standalone')
+    workingDirectory: path.join(process.cwd(), 'test')
   });
   var logger = common.logger({ logLevel: config.logLevel });
   var api = null;
@@ -71,12 +71,11 @@ describe('v8debugapi', function() {
     }
   });
   afterEach(function() { assert(stateIsClean(api)); });
-  it('Should be able to read the argument and the context', function(done) {
-      var brk = {
-        id: 'fake-id-123',
-        location: { path: 'test-this-context.js', line: 5 }
-      };
-      var ctxMembers;
+  it('Should read e as the caught error', function(done) {
+    var brk = {
+      id: 'fake-id-123',
+      location: { path: 'test-try-catch.js', line: 7 }
+    };
     api.set(brk, function(err) {
       assert.ifError(err);
       api.wait(brk, function(err) {
@@ -84,36 +83,31 @@ describe('v8debugapi', function() {
         var frame = brk.stackFrames[0];
         var args = frame.arguments;
         var locals = frame.locals;
-        ctxMembers = brk.variableTable.slice(brk.variableTable.length-1)[0]
-          .members;
-        assert.deepEqual(ctxMembers.length, 1, 
-          'There should be one member in the context variable value');
-        assert.deepEqual(ctxMembers[0], {name: 'a', value: '10'});
+        assert.equal(locals.length, 1, 'There should be one local');
         if (semver.satisfies(process.version, '<1.6')) {
-            assert.equal(args.length, 1, 'There should be one argument');
-            assert.equal(locals.length, 1, 'There should be one local');
-            assert.deepEqual(
-              args[0],
-              {name: 'b', value: '1'}
-   	   	    );
-            assert.deepEqual(locals[0].name, 'context');
+          // Try/Catch scope-walking does not work on 0.12
+          assert.deepEqual(
+            locals[0],
+            {name: 'e', value: 'undefined'}
+          );
         } else {
           assert.equal(args.length, 0, 'There should be zero arguments');
-          assert.equal(locals.length, 2, 'There should be two locals');
-          assert.deepEqual(locals[0], {name: 'b', value: '1'});
-          assert.deepEqual(locals[1].name, 'context');
+          var e = locals[0];
+          assert(e.name === 'e');
+          assert(Number.isInteger(e.varTableIndex));
         }
+        assert.equal(args.length, 0, 'There should be zero arguments');     
         api.clear(brk);
         done();
       });
-      process.nextTick(foo.bind({}, 1));
+      process.nextTick(foo.bind(null, 'test'));
     });
   });
-  it('Should be able to read the argument and deny the context', function(done) {
-      var brk = {
-        id: 'fake-id-123',
-        location: { path: 'test-this-context.js', line: 9 }
-      };
+  it('Should read e as the local error', function(done) {
+    var brk = {
+      id: 'fake-id-123',
+      location: { path: 'test-try-catch.js', line: 8 }
+    };
     api.set(brk, function(err) {
       assert.ifError(err);
       api.wait(brk, function(err) {
@@ -122,21 +116,24 @@ describe('v8debugapi', function() {
         var args = frame.arguments;
         var locals = frame.locals;
         if (semver.satisfies(process.version, '<1.6')) {
-            assert.equal(args.length, 1, 'There should be one argument');
-            assert.equal(locals.length, 0);
-             assert.deepEqual(
-              args[0],
-              {name: 'j', value: '1'}
-   	   	    );
+          // Try/Catch scope-walking does not work on 0.12
+          assert.deepEqual(
+            locals[0],
+            {name: 'e', value: 'undefined'}
+          );
         } else {
           assert.equal(args.length, 0, 'There should be zero arguments');
           assert.equal(locals.length, 1, 'There should be one local');
-          assert.deepEqual(locals[0], {name: 'j', value: '1'});
+          assert.deepEqual(
+            locals[0],
+            {name: 'e', value: '2'}
+          );
+          assert.equal(args.length, 0, 'There should be zero arguments');
         }
         api.clear(brk);
         done();
       });
-      process.nextTick(bar.bind(null, 1));
+      process.nextTick(foo.bind(null, 'test'));
     });
   });
 });

--- a/test/test-try-catch.js
+++ b/test/test-try-catch.js
@@ -45,7 +45,7 @@ function stateIsClean(api) {
 describe('v8debugapi', function() {
   var config = extend({}, defaultConfig, {
     workingDirectory: path.join(process.cwd(), 'test'),
-    force_: true
+    forceNewAgent_: true
   });
   var logger = common.logger({ logLevel: config.logLevel });
   var api = null;

--- a/test/test-v8debugapi.js
+++ b/test/test-v8debugapi.js
@@ -33,12 +33,12 @@ var MAX_INT = 2147483647; // Max signed int32.
 
 var assert = require('assert');
 var extend = require('extend');
-var v8debugapi = require('../../src/agent/v8debugapi.js');
+var v8debugapi = require('../src/agent/v8debugapi.js');
 var common = require('@google-cloud/common');
-var defaultConfig = require('../../src/agent/config.js');
-var StatusMessage = require('../../src/status-message.js');
-var scanner = require('../../src/agent/scanner.js');
-var SourceMapper = require('../../src/agent/sourcemapper.js');
+var defaultConfig = require('../src/agent/config.js');
+var StatusMessage = require('../src/status-message.js');
+var scanner = require('../src/agent/scanner.js');
+var SourceMapper = require('../src/agent/sourcemapper.js');
 var path = require('path');
 var semver = require('semver');
 
@@ -173,7 +173,7 @@ describe('v8debugapi', function() {
 
   it('should set error for breakpoint in non-js files',
     function(done) {
-      require('../fixtures/key-bad.json');
+      require('./fixtures/key-bad.json');
       var bp = { id: 0, location: {line: 1, path: path.join('fixtures',
         'key-bad.json')}};
       api.set(bp, function(err) {
@@ -188,7 +188,7 @@ describe('v8debugapi', function() {
 
   it('should disambiguate incorrect path if filename is unique',
     function(done) {
-      require('../fixtures/foo.js');
+      require('./fixtures/foo.js');
       var bp = { id: 0, location: {line: 1, path: path.join(path.sep, 'test',
         'foo.js')}};
       api.set(bp, function(err) {
@@ -200,7 +200,7 @@ describe('v8debugapi', function() {
 
   it('should disambiguate incorrect path if partial path is unique',
     function(done) {
-      require('../fixtures/foo.js');
+      require('./fixtures/foo.js');
       // hello.js is not unique but a/hello.js is.
       var bp = { id: 0, location: {line: 1, path: path.join(path.sep, 'Server',
         'a', 'hello.js')}};
@@ -235,8 +235,8 @@ describe('v8debugapi', function() {
     });
 
     it('should reject breakpoint when filename is ambiguous', function(done) {
-      require('../fixtures/a/hello.js');
-      require('../fixtures/b/hello.js');
+      require('./fixtures/a/hello.js');
+      require('./fixtures/b/hello.js');
       var bp = {id: 'ambiguous', location: {line: 1, path: 'hello.js'}};
       api.set(bp, function(err) {
         assert.ok(err);
@@ -250,10 +250,10 @@ describe('v8debugapi', function() {
     });
 
     it('should reject breakpoint on non-existent line', function(done) {
-      require('../fixtures/foo.js');
+      require('./fixtures/foo.js');
       var bp = {
         id: 'non-existent line',
-        location: {path: path.join('..', 'fixtures', 'foo.js'), line: 500}
+        location: {path: path.join('fixtures', 'foo.js'), line: 500}
       };
       api.set(bp, function(err) {
         assert.ok(err);
@@ -979,7 +979,7 @@ describe('v8debugapi', function() {
             'transpile.coffee'), line: 3 },
           condition: 'if n == 3 then true else false'
         };
-        var tt = require('../fixtures/coffee/transpile');
+        var tt = require('./fixtures/coffee/transpile');
         api.set(bp, function(err) {
           assert.ifError(err);
           api.wait(bp, function(err) {
@@ -1025,7 +1025,7 @@ describe('v8debugapi', function() {
             line: 3 },
           condition: 'i + j === 3'
         };
-        var tt = require('../fixtures/es6/transpile');
+        var tt = require('./fixtures/es6/transpile');
         api.set(bp, function(err) {
           assert.ifError(err);
           api.wait(bp, function(err) {
@@ -1056,7 +1056,7 @@ describe('v8debugapi', function() {
               'transpile.coffee'), line: 3 },
             expressions: ['if n == 3 then Math.PI * n else n']
           };
-        var tt = require('../fixtures/coffee/transpile');
+        var tt = require('./fixtures/coffee/transpile');
         api.set(bp, function(err) {
           assert.ifError(err);
           api.wait(bp, function(err) {
@@ -1086,7 +1086,7 @@ describe('v8debugapi', function() {
               line: 3 },
             expressions: [':)', 'n n, n', 'process=this', '((x) -> x x) n', 'return']
           };
-        var tt = require('../fixtures/coffee/transpile');
+        var tt = require('./fixtures/coffee/transpile');
         api.set(bp, function(err) {
           assert.ifError(err);
           api.wait(bp, function(err) {
@@ -1160,7 +1160,7 @@ describe('v8debugapi', function() {
 
 
     it('should correctly stop on line-1 breakpoints', function(done) {
-      var foo = require('../fixtures/foo.js');
+      var foo = require('./fixtures/foo.js');
       var bp = { id: 'bp-line-1', location: {
         path: 'foo.js',
         line: 1,

--- a/test/test-v8debugapi.js
+++ b/test/test-v8debugapi.js
@@ -114,7 +114,7 @@ function validateBreakpoint(breakpoint) {
 describe('v8debugapi', function() {
   var config = extend({}, defaultConfig, {
     workingDirectory: path.join(process.cwd(), 'test'),
-    force_: true
+    forceNewAgent_: true
   });
   var logger = common.logger({ logLevel: config.logLevel });
   var api = null;

--- a/test/test-v8debugapi.js
+++ b/test/test-v8debugapi.js
@@ -113,7 +113,8 @@ function validateBreakpoint(breakpoint) {
 
 describe('v8debugapi', function() {
   var config = extend({}, defaultConfig, {
-    workingDirectory: path.join(process.cwd(), 'test')
+    workingDirectory: path.join(process.cwd(), 'test'),
+    force_: true
   });
   var logger = common.logger({ logLevel: config.logLevel });
   var api = null;


### PR DESCRIPTION
Moved remaining `standalone tests` to the root `test` folder.

The simplest way to go about this was to introduce an undocumented, debug-only flag `force_`, that allows both the debug agent and V8 debug API singletons to be re-assigned. I'm open to doing this a different way, however, like a `stop` function.