### PR TITLE
Remove misleading arguments/locals message

### DIFF
--- a/test/standalone/test-duplicate-nested-expressions.js
+++ b/test/standalone/test-duplicate-nested-expressions.js
@@ -89,11 +89,9 @@ describe('v8debugapi', function() {
               args[0],
               {name: 'a', value: '11'}
    	   	    );
-            assert.equal(locals.length, 1);
-            assert.equal(locals[0].name, 'locals_not_available');
+            assert.equal(locals.length, 0);
         } else {
-          assert.equal(args.length, 1, 'There should be one argument');
-          assert.equal(args[0].name, 'arguments_not_available');
+          assert.equal(args.length, 0, 'There should be zero arguments');
           assert.equal(locals.length, 1, 'There should be one locals');
           assert.deepEqual(
             locals[0],
@@ -125,11 +123,9 @@ describe('v8debugapi', function() {
               args[0],
               {name: 'a', value: '11'}
    	   	    );
-            assert.equal(locals.length, 1);
-            assert.equal(locals[0].name, 'locals_not_available');
+            assert.equal(locals.length, 0);
         } else {
-          assert.equal(args.length, 1, 'There should be one argument');
-          assert.equal(args[0].name, 'arguments_not_available');
+          assert.equal(args.length, 0, 'There should be zero arguments');
           assert.equal(locals.length, 1, 'There should be one local');
           assert.deepEqual(
             locals[0],
@@ -161,11 +157,9 @@ describe('v8debugapi', function() {
               args[0],
               {name: 'a', value: '11'}
    	   	    );
-            assert.equal(locals.length, 1);
-            assert.equal(locals[0].name, 'locals_not_available');
+            assert.equal(locals.length, 0);
         } else {
-          assert.equal(args.length, 1, 'There should be one argument');
-          assert.equal(args[0].name, 'arguments_not_available');
+          assert.equal(args.length, 0, 'There should be zero arguments');
           assert.equal(locals.length, 1, 'There should be one local');
           assert.deepEqual(
             locals[0],
@@ -200,8 +194,7 @@ describe('v8debugapi', function() {
         var frame = brk.stackFrames[0];
         var args = frame.arguments;
         var locals = frame.locals;
-        assert.equal(args.length, 1, 'There should be one argument');
-        assert.equal(args[0].name, 'arguments_not_available');
+        assert.equal(args.length, 0, 'There should be zero arguments');
         assert.equal(locals.length, 2, 'There should be two locals');
         assert.deepEqual(
           locals[0],

--- a/test/standalone/test-fat-arrow.js
+++ b/test/standalone/test-fat-arrow.js
@@ -84,8 +84,7 @@ describe('v8debugapi', function() {
         var frame = brk.stackFrames[0];
         var args = frame.arguments;
         var locals = frame.locals;
-        assert.equal(args.length, 1, 'There should be one argument');
-        assert.equal(args[0].name, 'arguments_not_available');
+        assert.equal(args.length, 0, 'There should be zero arguments');
         assert.equal(locals.length, 1, 'There should be one local');
         assert.deepEqual(
           locals[0],
@@ -109,8 +108,7 @@ describe('v8debugapi', function() {
         var frame = brk.stackFrames[0];
         var args = frame.arguments;
         var locals = frame.locals;
-        assert.equal(args.length, 1, 'There should be one argument');
-        assert.equal(args[0].name, 'arguments_not_available');
+        assert.equal(args.length, 0, 'There should be zero arguments');
         assert.equal(locals.length, 1, 'There should be one local');
         assert.deepEqual(
           locals[0],

--- a/test/standalone/test-this-context.js
+++ b/test/standalone/test-this-context.js
@@ -98,8 +98,7 @@ describe('v8debugapi', function() {
    	   	    );
             assert.deepEqual(locals[0].name, 'context');
         } else {
-          assert.equal(args.length, 1, 'There should be one argument');
-          assert.equal(args[0].name, 'arguments_not_available');
+          assert.equal(args.length, 0, 'There should be zero arguments');
           assert.equal(locals.length, 2, 'There should be two locals');
           assert.deepEqual(locals[0], {name: 'b', value: '1'});
           assert.deepEqual(locals[1].name, 'context');
@@ -124,15 +123,13 @@ describe('v8debugapi', function() {
         var locals = frame.locals;
         if (semver.satisfies(process.version, '<1.6')) {
             assert.equal(args.length, 1, 'There should be one argument');
-            assert.equal(locals.length, 1, 'There should be one local');
+            assert.equal(locals.length, 0);
              assert.deepEqual(
               args[0],
               {name: 'j', value: '1'}
    	   	    );
-            assert.equal(locals[0].name, 'locals_not_available');
         } else {
-          assert.equal(args.length, 1, 'There should be one argument');
-          assert.equal(args[0].name, 'arguments_not_available');
+          assert.equal(args.length, 0, 'There should be zero arguments');
           assert.equal(locals.length, 1, 'There should be one local');
           assert.deepEqual(locals[0], {name: 'j', value: '1'});
         }

--- a/test/standalone/test-try-catch.js
+++ b/test/standalone/test-try-catch.js
@@ -83,7 +83,6 @@ describe('v8debugapi', function() {
         var frame = brk.stackFrames[0];
         var args = frame.arguments;
         var locals = frame.locals;
-        assert.equal(args.length, 1, 'There should be one argument');
         assert.equal(locals.length, 1, 'There should be one local');
         if (semver.satisfies(process.version, '<1.6')) {
           // Try/Catch scope-walking does not work on 0.12
@@ -92,13 +91,12 @@ describe('v8debugapi', function() {
             {name: 'e', value: 'undefined'}
           );
         } else {
+          assert.equal(args.length, 0, 'There should be zero arguments');
           var e = locals[0];
           assert(e.name === 'e');
           assert(Number.isInteger(e.varTableIndex));
         }
-        var arg0 = args[0];
-        assert(arg0.name === 'arguments_not_available');
-        assert(Number.isInteger(arg0.varTableIndex));      
+        assert.equal(args.length, 0, 'There should be zero arguments');     
         api.clear(brk);
         done();
       });
@@ -124,15 +122,13 @@ describe('v8debugapi', function() {
             {name: 'e', value: 'undefined'}
           );
         } else {
-          assert.equal(args.length, 1, 'There should be one argument');
+          assert.equal(args.length, 0, 'There should be zero arguments');
           assert.equal(locals.length, 1, 'There should be one local');
           assert.deepEqual(
             locals[0],
             {name: 'e', value: '2'}
           );
-          var arg0 = args[0];
-          assert(arg0.name === 'arguments_not_available');
-          assert(Number.isInteger(arg0.varTableIndex));
+          assert.equal(args.length, 0, 'There should be zero arguments');
         }
         api.clear(brk);
         done();


### PR DESCRIPTION
When within the frame capture range omit status
messages declaming that arguments/locals are only
captured for frames in the capture range.