### PR TITLE
Relax configuration rules for agent

### DIFF
--- a/src/agent/debuglet.js
+++ b/src/agent/debuglet.js
@@ -155,14 +155,7 @@ Debuglet.normalizeConfig_ = function(config) {
     }
   };
 
-  config = extend(true, {}, defaultConfig, config, envConfig);
-
-  if (config.keyFilename || config.credentials || config.projectId) {
-    throw new Error('keyFilename, projectId or credentials should be provided' +
-                    ' to the Debug module constructor rather than startAgent');
-  }
-
-  return config;
+  return extend(true, {}, defaultConfig, config, envConfig);
 };
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -38,11 +38,11 @@ var debuglet;
  */
 function start(options) {
   options = options || {};
-  var agentConfig = options.debug || {};
+  var agentConfig = options.debug || options;
 
   // forceNewAgent_ is for testing purposes only.
   if (debuglet && !agentConfig.forceNewAgent_) {
-    throw new Error('Debug Agent has already been starterd');
+    throw new Error('Debug Agent has already been started');
   }
 
   var debug = new Debug(options);


### PR DESCRIPTION
With this change, we will use the option object for agent configuration if options.debug does not exist.