### PR TITLE
update deps v0.9.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "proxyquire": "^1.4.0"
   },
   "dependencies": {
-    "@google/cloud-diagnostics-common": "0.3.0",
+    "@google/cloud-diagnostics-common": "0.3.1",
     "acorn": "^4.0.3",
     "async": "^2.1.2",
     "coffee-script": "^1.9.3",


### PR DESCRIPTION
Update deps on the v0.9.x branch corresponding to old google/cloud-debug module name. It still has some usage, so it is worth getting rid of the concat-stream vulnerability: https://snyk.io/vuln/npm:concat-stream:20160901