### PR TITLE
Update deps, drop support for 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 dist: trusty
 node_js:
-- '0.12'
 - '4'
 - '6'
 - '7'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This module provides Stackdriver Debugger support for Node.js applications. [Sta
 [![Cloud Debugger Intro](http://img.youtube.com/vi/tyHcK_kAOpw/0.jpg)](https://www.youtube.com/watch?v=tyHcK_kAOpw)
 
 ## Prerequisites
-* Stackdriver Debugger is comptible with Node.js version 0.12 or greater. Node.js v5+ is recommended.
+* Stackdriver Debugger is comptible with Node.js version 4 or greater. Node.js v5+ is recommended.
 
 ## Quick Start
 ```shell

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=0.12"
+    "node": ">=4"
   },
   "devDependencies": {
     "changelog-maker": "^2.2.2",
@@ -28,17 +28,18 @@
     "istanbul": "^0.4.1",
     "jshint": "^2.7.0",
     "mocha": "^3.0.0",
-    "nock": "^9.0.0"
+    "nock": "^9.0.0",
+    "proxyquire": "^1.7.11",
+    "request": "^2.81.0"
   },
   "dependencies": {
-    "@google-cloud/common": "^0.12.0",
-    "acorn": "^4.0.3",
+    "@google-cloud/common": "^0.13.3",
+    "acorn": "^5.0.3",
     "async": "^2.1.2",
     "coffee-script": "^1.9.3",
     "findit2": "^2.2.3",
-    "gcp-metadata": "^0.1.0",
+    "gcp-metadata": "^0.2.0",
     "lodash": "^4.12.0",
-    "request": "^2.61.0",
     "semver": "^5.1.0",
     "source-map": "^0.5.1",
     "split": "^1.0.0"

--- a/src/agent/debuglet.js
+++ b/src/agent/debuglet.js
@@ -215,7 +215,7 @@ Debuglet.prototype.start = function() {
               // This is ignorable.
             }
 
-            if (semver.satisfies(process.version, '5.2 || <0.12')) {
+            if (semver.satisfies(process.version, '5.2 || <4')) {
               // Using an unsupported version. We report an error message about the
               // Node.js version, but we keep on running. The idea is that the user
               // may miss the error message on the console. This way we can report the
@@ -550,7 +550,7 @@ Debuglet.prototype.addBreakpoint_ = function(breakpoint, cb) {
     return;
   }
 
-  if (semver.satisfies(process.version, '5.2 || <0.12')) {
+  if (semver.satisfies(process.version, '5.2 || <4')) {
     var message = NODE_VERSION_MESSAGE;
     that.logger_.error(message);
     breakpoint.status = new StatusMessage(StatusMessage.UNSPECIFIED,

--- a/test/test-debuglet.js
+++ b/test/test-debuglet.js
@@ -15,6 +15,11 @@
  */
 'use strict';
 
+var proxyquire = require('proxyquire');
+proxyquire('gcp-metadata', {
+  'retry-request': require('request')
+});
+
 var _ = require('lodash');
 var assert = require('assert');
 var DEFAULT_CONFIG = require('../src/agent/config.js');
@@ -78,15 +83,9 @@ describe('Debuglet', function() {
       var debug = require('../src/debug.js')();
       var debuglet = new Debuglet(debug, defaultConfig);
 
-      // The following mock is neccessary for the case when the test is running
-      // on GCP. In that case we will get the projectId from the metadata
-      // service.
-      var scope = nocks.projectId(404);
-
       debuglet.once('initError', function(err) {
         assert.ok(err);
         // no need to stop the debuggee.
-        scope.done();
         done();
       });
       debuglet.once('started', function() { assert.fail(); });
@@ -98,14 +97,8 @@ describe('Debuglet', function() {
       var debug = require('../src/debug.js')();
       var debuglet = new Debuglet(debug, defaultConfig);
 
-      // The following mock is neccessary for the case when the test is running
-      // on GCP. In that case we will get the projectId from the metadata
-      // service.
-      var scope = nocks.projectId(404);
-
       debuglet.once('started', function() { assert.fail(); });
       debuglet.once('initError', function() {
-        scope.done();
         done();
       });
       debuglet.start();

--- a/test/test-duplicate-nested-expressions.js
+++ b/test/test-duplicate-nested-expressions.js
@@ -31,7 +31,6 @@ var common = require('@google-cloud/common');
 var defaultConfig = require('../src/agent/config.js');
 var SourceMapper = require('../src/agent/sourcemapper.js');
 var scanner = require('../src/agent/scanner.js');
-var semver = require('semver');
 
 function stateIsClean(api) {
   assert.equal(api.numBreakpoints_(), 0,
@@ -83,21 +82,12 @@ describe(__filename, function() {
         var frame = brk.stackFrames[0];
         var args = frame.arguments;
         var locals = frame.locals;
-        if (semver.satisfies(process.version, '<1.6')) {
-            assert.equal(args.length, 1, 'There should be one argument');
-            assert.deepEqual(
-              args[0],
-              {name: 'a', value: '11'}
-   	   	    );
-            assert.equal(locals.length, 0);
-        } else {
-          assert.equal(args.length, 0, 'There should be zero arguments');
-          assert.equal(locals.length, 1, 'There should be one locals');
-          assert.deepEqual(
-            locals[0],
-            {name: 'a', value: 'test'}
-   	      );
-        }
+        assert.equal(args.length, 0, 'There should be zero arguments');
+        assert.equal(locals.length, 1, 'There should be one locals');
+        assert.deepEqual(
+          locals[0],
+          {name: 'a', value: 'test'}
+ 	      );
         api.clear(brk);
         done();
       });
@@ -117,21 +107,12 @@ describe(__filename, function() {
         var frame = brk.stackFrames[0];
         var args = frame.arguments;
         var locals = frame.locals;
-        if (semver.satisfies(process.version, '<1.6')) {
-            assert.equal(args.length, 1, 'There should be one argument');
-            assert.deepEqual(
-              args[0],
-              {name: 'a', value: '11'}
-   	   	    );
-            assert.equal(locals.length, 0);
-        } else {
-          assert.equal(args.length, 0, 'There should be zero arguments');
-          assert.equal(locals.length, 1, 'There should be one local');
-          assert.deepEqual(
-            locals[0],
-            {name: 'a', value: '10'}
-          );
-        }
+        assert.equal(args.length, 0, 'There should be zero arguments');
+        assert.equal(locals.length, 1, 'There should be one local');
+        assert.deepEqual(
+          locals[0],
+          {name: 'a', value: '10'}
+        );
         api.clear(brk);
         done();
       });
@@ -151,21 +132,12 @@ describe(__filename, function() {
         var frame = brk.stackFrames[0];
         var args = frame.arguments;
         var locals = frame.locals;
-        if (semver.satisfies(process.version, '<1.6')) {
-            assert.equal(args.length, 1, 'There should be one argument');
-            assert.deepEqual(
-              args[0],
-              {name: 'a', value: '11'}
-   	   	    );
-            assert.equal(locals.length, 0);
-        } else {
-          assert.equal(args.length, 0, 'There should be zero arguments');
-          assert.equal(locals.length, 1, 'There should be one local');
-          assert.deepEqual(
-            locals[0],
-            {name: 'a', value: '11'}
-          );
-        }
+        assert.equal(args.length, 0, 'There should be zero arguments');
+        assert.equal(locals.length, 1, 'There should be one local');
+        assert.deepEqual(
+          locals[0],
+          {name: 'a', value: '11'}
+        );
         api.clear(brk);
         done();
       });
@@ -178,15 +150,6 @@ describe(__filename, function() {
       id: 'fake-id-1234',
       location: { path: 'test-duplicate-nested-expressions.js', line: 8 }
     };
-    if (semver.satisfies(process.version, '<1.6')) {
-      // this IIFE test does not work on 0.12. Specifically the IIFE never
-      // executes and, therefore, the breakpoint is never hit. This will require
-      // further investigation as to what is causing the IIFE not to execute.a
-      // @TODO cristiancavalli - investigate why this IIFE does not execute
-      console.log('Skipping IIFE test due to Node.JS version requirements');
-      this.skip();
-      return;
-    }
     api.set(brk, function(err) {
       assert.ifError(err);
       api.wait(brk, function(err) {

--- a/test/test-fat-arrow.js
+++ b/test/test-fat-arrow.js
@@ -22,7 +22,6 @@ var common = require('@google-cloud/common');
 var defaultConfig = require('../src/agent/config.js');
 var SourceMapper = require('../src/agent/sourcemapper.js');
 var scanner = require('../src/agent/scanner.js');
-var semver = require('semver');
 
 process.env.GCLOUD_PROJECT = 0;
 
@@ -43,13 +42,6 @@ describe(__filename, function() {
   var api = null;
   var foo;
   before(function () {
-    if (semver.satisfies(process.version, '<4.0')) {
-      // Fat arrow syntax is not recognized by these node versions - skip tests.
-      console.log('Skipping fat-arrow syntax due to Node.JS version being ' +
-        'lower than requirements');
-      this.skip();
-      return;
-    }
     foo = require('./fixtures/fat-arrow.js');
   });
   beforeEach(function(done) {

--- a/test/test-this-context.js
+++ b/test/test-this-context.js
@@ -31,7 +31,6 @@ var common = require('@google-cloud/common');
 var defaultConfig = require('../src/agent/config.js');
 var SourceMapper = require('../src/agent/sourcemapper.js');
 var scanner = require('../src/agent/scanner.js');
-var semver = require('semver');
 
 function stateIsClean(api) {
   assert.equal(api.numBreakpoints_(), 0,
@@ -89,20 +88,10 @@ describe(__filename, function() {
         assert.deepEqual(ctxMembers.length, 1, 
           'There should be one member in the context variable value');
         assert.deepEqual(ctxMembers[0], {name: 'a', value: '10'});
-        if (semver.satisfies(process.version, '<1.6')) {
-            assert.equal(args.length, 1, 'There should be one argument');
-            assert.equal(locals.length, 1, 'There should be one local');
-            assert.deepEqual(
-              args[0],
-              {name: 'b', value: '1'}
-   	   	    );
-            assert.deepEqual(locals[0].name, 'context');
-        } else {
-          assert.equal(args.length, 0, 'There should be zero arguments');
-          assert.equal(locals.length, 2, 'There should be two locals');
-          assert.deepEqual(locals[0], {name: 'b', value: '1'});
-          assert.deepEqual(locals[1].name, 'context');
-        }
+        assert.equal(args.length, 0, 'There should be zero arguments');
+        assert.equal(locals.length, 2, 'There should be two locals');
+        assert.deepEqual(locals[0], {name: 'b', value: '1'});
+        assert.deepEqual(locals[1].name, 'context');
         api.clear(brk);
         done();
       });
@@ -121,18 +110,9 @@ describe(__filename, function() {
         var frame = brk.stackFrames[0];
         var args = frame.arguments;
         var locals = frame.locals;
-        if (semver.satisfies(process.version, '<1.6')) {
-            assert.equal(args.length, 1, 'There should be one argument');
-            assert.equal(locals.length, 0);
-             assert.deepEqual(
-              args[0],
-              {name: 'j', value: '1'}
-   	   	    );
-        } else {
-          assert.equal(args.length, 0, 'There should be zero arguments');
-          assert.equal(locals.length, 1, 'There should be one local');
-          assert.deepEqual(locals[0], {name: 'j', value: '1'});
-        }
+        assert.equal(args.length, 0, 'There should be zero arguments');
+        assert.equal(locals.length, 1, 'There should be one local');
+        assert.deepEqual(locals[0], {name: 'j', value: '1'});
         api.clear(brk);
         done();
       });

--- a/test/test-try-catch.js
+++ b/test/test-try-catch.js
@@ -31,7 +31,6 @@ var common = require('@google-cloud/common');
 var defaultConfig = require('../src/agent/config.js');
 var SourceMapper = require('../src/agent/sourcemapper.js');
 var scanner = require('../src/agent/scanner.js');
-var semver = require('semver');
 
 function stateIsClean(api) {
   assert.equal(api.numBreakpoints_(), 0,
@@ -84,18 +83,10 @@ describe(__filename, function() {
         var args = frame.arguments;
         var locals = frame.locals;
         assert.equal(locals.length, 1, 'There should be one local');
-        if (semver.satisfies(process.version, '<1.6')) {
-          // Try/Catch scope-walking does not work on 0.12
-          assert.deepEqual(
-            locals[0],
-            {name: 'e', value: 'undefined'}
-          );
-        } else {
-          assert.equal(args.length, 0, 'There should be zero arguments');
-          var e = locals[0];
-          assert(e.name === 'e');
-          assert(Number.isInteger(e.varTableIndex));
-        }
+        assert.equal(args.length, 0, 'There should be zero arguments');
+        var e = locals[0];
+        assert(e.name === 'e');
+        assert(Number.isInteger(e.varTableIndex));
         assert.equal(args.length, 0, 'There should be zero arguments');     
         api.clear(brk);
         done();
@@ -115,21 +106,13 @@ describe(__filename, function() {
         var frame = brk.stackFrames[0];
         var args = frame.arguments;
         var locals = frame.locals;
-        if (semver.satisfies(process.version, '<1.6')) {
-          // Try/Catch scope-walking does not work on 0.12
-          assert.deepEqual(
-            locals[0],
-            {name: 'e', value: 'undefined'}
-          );
-        } else {
-          assert.equal(args.length, 0, 'There should be zero arguments');
-          assert.equal(locals.length, 1, 'There should be one local');
-          assert.deepEqual(
-            locals[0],
-            {name: 'e', value: '2'}
-          );
-          assert.equal(args.length, 0, 'There should be zero arguments');
-        }
+        assert.equal(args.length, 0, 'There should be zero arguments');
+        assert.equal(locals.length, 1, 'There should be one local');
+        assert.deepEqual(
+          locals[0],
+          {name: 'e', value: '2'}
+        );
+        assert.equal(args.length, 0, 'There should be zero arguments');
         api.clear(brk);
         done();
       });

--- a/test/test-v8debugapi.js
+++ b/test/test-v8debugapi.js
@@ -519,17 +519,10 @@ describe('v8debugapi', function() {
           var topFrame = bp.stackFrames[0];
           assert.ok(topFrame);
           assert.equal(topFrame['function'], 'foo');
-          if (semver.satisfies(process.version, '<1.6')) {
-            assert.equal(topFrame.arguments[0].name, 'n');
-            assert.equal(topFrame.arguments[0].value, '2');
-            assert.equal(topFrame.locals[0].name, 'A');
-            assert.equal(topFrame.locals[1].name, 'B');
-          } else {
-            assert.equal(topFrame.locals[0].name, 'n');
-            assert.equal(topFrame.locals[0].value, '2');
-            assert.equal(topFrame.locals[1].name, 'A');
-            assert.equal(topFrame.locals[2].name, 'B');
-          }
+          assert.equal(topFrame.locals[0].name, 'n');
+          assert.equal(topFrame.locals[0].value, '2');
+          assert.equal(topFrame.locals[1].name, 'A');
+          assert.equal(topFrame.locals[2].name, 'B');
           api.clear(bp);
           done();
         });
@@ -587,13 +580,8 @@ describe('v8debugapi', function() {
           var topFrame = bp.stackFrames[0];
           assert.ok(topFrame);
           assert.equal(topFrame['function'], 'foo');
-          if (semver.satisfies(process.version, '<1.6')) {
-            assert.equal(topFrame.arguments[0].name, 'n');
-            assert.equal(topFrame.arguments[0].value, '2');
-          } else {
-            assert.equal(topFrame.locals[0].name, 'n');
-            assert.equal(topFrame.locals[0].value, '2');
-          }
+          assert.equal(topFrame.locals[0].name, 'n');
+          assert.equal(topFrame.locals[0].value, '2');
           api.clear(bp);
           config.capture.maxFrames = oldMax;
           done();
@@ -623,13 +611,8 @@ describe('v8debugapi', function() {
 
           var topFrame = bp.stackFrames[0];
           assert.equal(topFrame['function'], 'foo');
-          if (semver.satisfies(process.version, '<1.6')) {
-            assert.equal(topFrame.arguments[0].name, 'n');
-            assert.equal(topFrame.arguments[0].value, '3');
-          } else {
-            assert.equal(topFrame.locals[0].name, 'n');
-            assert.equal(topFrame.locals[0].value, '3');
-          }
+          assert.equal(topFrame.locals[0].name, 'n');
+          assert.equal(topFrame.locals[0].value, '3');
 
           var watch = bp.evaluatedExpressions[0];
           assert.equal(watch.name, 'process');
@@ -694,9 +677,6 @@ describe('v8debugapi', function() {
     });
 
     it('should work with array length despite being native', function(done) {
-      if (semver.satisfies(process.version, '<1.0')) {
-        return done();
-      }
       var bp  = {
         id: breakpointInFoo.id,
         location:  { path: 'test-v8debugapi.js', line: 5 },
@@ -957,13 +937,8 @@ describe('v8debugapi', function() {
           assert.ok(bp.stackFrames);
 
           var topFrame = bp.stackFrames[0];
-          if (semver.satisfies(process.version, '<1.6')) {
-            assert.equal(topFrame.arguments[0].name, 'n');
-            assert.equal(topFrame.arguments[0].value, '5');
-          } else {
-            assert.equal(topFrame.locals[0].name, 'n');
-            assert.equal(topFrame.locals[0].value, '5');
-          }
+          assert.equal(topFrame.locals[0].name, 'n');
+          assert.equal(topFrame.locals[0].value, '5');
           api.clear(bp);
           done();
         });
@@ -989,13 +964,8 @@ describe('v8debugapi', function() {
 
             var topFrame = bp.stackFrames[0];
             assert.equal(topFrame['function'], 'foo');
-            if (semver.satisfies(process.version, '<1.6')) {
-              assert.equal(topFrame.arguments[0].name, 'n');
-              assert.equal(topFrame.arguments[0].value, '3');
-            } else {
-              assert.equal(topFrame.locals[0].name, 'n');
-              assert.equal(topFrame.locals[0].value, '3');
-            }
+            assert.equal(topFrame.locals[0].name, 'n');
+            assert.equal(topFrame.locals[0].value, '3');
             api.clear(bp);
             done();
           });
@@ -1034,13 +1004,8 @@ describe('v8debugapi', function() {
             assert.ok(bp.stackFrames);
 
             var topFrame = bp.stackFrames[0];
-            if (semver.satisfies(process.version, '<1.6')) {
-              assert.equal(topFrame.arguments[0].name, 'j');
-              assert.equal(topFrame.arguments[0].value, '2');
-            } else {
-              assert.equal(topFrame.locals[0].name, 'j');
-              assert.equal(topFrame.locals[0].value, '2');
-            }
+            assert.equal(topFrame.locals[0].name, 'j');
+            assert.equal(topFrame.locals[0].value, '2');
             assert.equal(topFrame['function'], 'foo');
             api.clear(bp);
             done();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@google-cloud/common@^0.12.0":
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/@google-cloud/common/-/common-0.12.2.tgz#78c344288c4605a29f4c2899391759d7dc817c43"
+"@google-cloud/common@^0.13.3":
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/@google-cloud/common/-/common-0.13.3.tgz#d73ee3fa511f29ffbcc44667898685709e9fec8c"
   dependencies:
     array-uniq "^1.0.3"
     arrify "^1.0.1"
@@ -13,13 +13,13 @@
     duplexify "^3.5.0"
     ent "^2.2.0"
     extend "^3.0.0"
-    google-auto-auth "^0.5.2"
+    google-auto-auth "^0.6.0"
     is "^3.2.0"
     log-driver "^1.2.5"
     methmeth "^1.1.0"
     modelo "^4.2.0"
     request "^2.79.0"
-    retry-request "^1.3.2"
+    retry-request "^2.0.0"
     split-array-stream "^1.0.0"
     stream-events "^1.0.1"
     string-format-obj "^1.1.0"
@@ -29,9 +29,9 @@ abbrev@1, abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
-acorn@^4.0.3:
-  version "4.0.11"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.11.tgz#edcda3bd937e7556410d42ed5860f67399c794c0"
+acorn@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
 
 ajv@^4.9.1:
   version "4.11.8"
@@ -475,6 +475,10 @@ esprima@2.7.x, esprima@^2.6.0, esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
+esprima@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+
 estraverse@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
@@ -498,6 +502,13 @@ extsprintf@1.0.2:
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
+fill-keys@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fill-keys/-/fill-keys-1.0.2.tgz#9a8fa36f4e8ad634e3bf6b4f3c8882551452eb20"
+  dependencies:
+    is-object "~1.0.1"
+    merge-descriptors "~1.0.0"
 
 findit2@^2.2.3:
   version "2.2.3"
@@ -525,6 +536,13 @@ gcp-metadata@^0.1.0:
   dependencies:
     extend "^3.0.0"
     retry-request "^1.3.2"
+
+gcp-metadata@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-0.2.0.tgz#62dafca65f3a631bc8ce2ec3b77661f5f9387a0a"
+  dependencies:
+    extend "^3.0.0"
+    retry-request "^2.0.0"
 
 generate-function@^2.0.0:
   version "2.0.0"
@@ -602,11 +620,12 @@ google-auth-library@^0.10.0:
     lodash.noop "^3.0.1"
     request "^2.74.0"
 
-google-auto-auth@^0.5.2:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/google-auto-auth/-/google-auto-auth-0.5.4.tgz#1d86c7928d633e75a9c1ab034a527efcce4a40b1"
+google-auto-auth@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/google-auto-auth/-/google-auto-auth-0.6.1.tgz#c05d820e9454739ecf28a8892eeab3d1624f2cb3"
   dependencies:
     async "^2.1.2"
+    gcp-metadata "^0.1.0"
     google-auth-library "^0.10.0"
     object-assign "^3.0.0"
     request "^2.79.0"
@@ -743,6 +762,10 @@ is-my-json-valid@^2.12.4:
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
 
+is-object@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
+
 is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
@@ -800,12 +823,19 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-js-yaml@3.6.1, js-yaml@3.x:
+js-yaml@3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
   dependencies:
     argparse "^1.0.7"
     esprima "^2.6.0"
+
+js-yaml@3.x:
+  version "3.8.4"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^3.1.1"
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -980,6 +1010,10 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
+merge-descriptors@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+
 methmeth@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/methmeth/-/methmeth-1.1.0.tgz#e80a26618e52f5c4222861bb748510bd10e29089"
@@ -1037,6 +1071,10 @@ mocha@^3.0.0:
 modelo@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/modelo/-/modelo-4.2.0.tgz#3b4b420023a66ca7e32bdba16e710937e14d1b0b"
+
+module-not-found-error@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
 
 ms@0.7.2:
   version "0.7.2"
@@ -1148,6 +1186,14 @@ process-nextick-args@~1.0.6:
 propagate@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-0.4.0.tgz#f3fcca0a6fe06736a7ba572966069617c130b481"
+
+proxyquire@^1.7.11:
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/proxyquire/-/proxyquire-1.7.11.tgz#13b494eb1e71fb21cc3ebe3699e637d3bec1af9e"
+  dependencies:
+    fill-keys "^1.0.2"
+    module-not-found-error "^1.0.0"
+    resolve "~1.1.7"
 
 punycode@^1.4.1:
   version "1.4.1"
@@ -1262,7 +1308,7 @@ request@2.79.0:
     tunnel-agent "~0.4.1"
     uuid "^3.0.0"
 
-request@^2.61.0, request@^2.72.0, request@^2.74.0, request@^2.79.0:
+request@^2.72.0, request@^2.74.0, request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -1289,7 +1335,7 @@ request@^2.61.0, request@^2.72.0, request@^2.74.0, request@^2.79.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-resolve@1.1.x:
+resolve@1.1.x, resolve@~1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
@@ -1298,6 +1344,13 @@ retry-request@^1.3.2:
   resolved "https://registry.yarnpkg.com/retry-request/-/retry-request-1.3.2.tgz#59ad24e71f8ae3f312d5f7b4bcf467a5e5a57bd6"
   dependencies:
     request "2.76.0"
+    through2 "^2.0.0"
+
+retry-request@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/retry-request/-/retry-request-2.0.1.tgz#fce3d5cc53e307c7dd1b4a6395bbfac1ea5ae664"
+  dependencies:
+    request "^2.81.0"
     through2 "^2.0.0"
 
 right-align@^0.1.1:


### PR DESCRIPTION
This change updates google-cloud/common to a version which is no longer
compatable with node v0.12. To upgrade this dependency, we must drop
support for 0.12 as well. Additionally, we prune out some code paths
that were only executed on node versions less than 1.6.