### PR TITLE
Avoid retries in e2e tests

### DIFF
--- a/test/fixtures/fib.js
+++ b/test/fixtures/fib.js
@@ -21,6 +21,11 @@ function fib(n) {
  * limitations under the License.
  */
 
+var proxyquire = require('proxyquire');
+proxyquire('gcp-metadata', {
+  'retry-request': require('request')
+});
+
 var debuglet = require('../..').start({
   debug: {
     logLevel: 2,


### PR DESCRIPTION
The new retry-request behavior was causing timeouts on the e2e tests. We
avoid this by using request instead.