### PR TITLE
Specify test-only client version in test debugger

### DIFF
--- a/test/debugger.js
+++ b/test/debugger.js
@@ -40,7 +40,7 @@ function Debugger(debug) {
   /** @private {string} */
   this.nextWaitToken_ = null;
 
-  this.clientVersion_ = pjson.name + '/client/v' + pjson.version;
+  this.clientVersion_ = pjson.name + '/client-for-testing/v' + pjson.version;
 }
 
 util.inherits(Debugger, common.ServiceObject);


### PR DESCRIPTION
This will allow monitoring tools to distinguish the debugger used for
our testing from real debugging tools.