### PR TITLE
stringify sourceContext before concat

### DIFF
--- a/src/agent/debuglet.js
+++ b/src/agent/debuglet.js
@@ -290,9 +290,8 @@ Debuglet.createDebuggee =
     desc += ' description:' + description;
   }
 
-  var uniquifier = desc + version + uid + JSON.stringify(sourceContext) + 
-      JSON.stringify(labels);
-  uniquifier = crypto.createHash('sha1').update(uniquifier).digest('hex');
+  var uniquifier = Debuglet._createUniquifier(desc, version, uid, sourceContext,
+      labels);
 
   var statusMessage =
       errorMessage ?
@@ -735,4 +734,12 @@ Debuglet._delimit = function(source, delim) {
     dest.push({ v: delim }, pieces[i]);
   }
   return dest;
+};
+
+Debuglet._createUniquifier = function (desc, version, uid, sourceContext,
+  labels) {
+  var uniquifier = desc + version + uid + JSON.stringify(sourceContext) +
+    JSON.stringify(labels);
+  uniquifier = crypto.createHash('sha1').update(uniquifier).digest('hex');
+  return uniquifier;
 };

--- a/src/agent/debuglet.js
+++ b/src/agent/debuglet.js
@@ -290,8 +290,8 @@ Debuglet.createDebuggee =
     desc += ' description:' + description;
   }
 
-  var uniquifier =
-      desc + version + uid + sourceContext + JSON.stringify(labels);
+  var uniquifier = desc + version + uid + JSON.stringify(sourceContext) + 
+      JSON.stringify(labels);
   uniquifier = crypto.createHash('sha1').update(uniquifier).digest('hex');
 
   var statusMessage =

--- a/src/agent/debuglet.js
+++ b/src/agent/debuglet.js
@@ -740,6 +740,5 @@ Debuglet._createUniquifier = function (desc, version, uid, sourceContext,
   labels) {
   var uniquifier = desc + version + uid + JSON.stringify(sourceContext) +
     JSON.stringify(labels);
-  uniquifier = crypto.createHash('sha1').update(uniquifier).digest('hex');
-  return uniquifier;
+  return crypto.createHash('sha1').update(uniquifier).digest('hex');
 };

--- a/test/test-debuglet.js
+++ b/test/test-debuglet.js
@@ -793,4 +793,43 @@ describe('Debuglet', function() {
        });
   });
 
+  describe('_createUniquifier', function () {
+    it('should create a unique string', function () {
+      var fn = Debuglet._createUniquifier;
+
+      var desc = 'description';
+      var version = 'version';
+      var uid = 'uid';
+      var sourceContext = {
+        git: 'something'
+      };
+      var labels = {
+        key: 'value'
+      };
+
+      var u1 = fn(desc, version, uid, sourceContext, labels);
+
+      assert.strictEqual(fn(desc, version, uid, sourceContext, labels), u1);
+
+      assert.notStrictEqual(
+        fn('foo', version, uid, sourceContext, labels),
+        u1,
+        'changing the description should change the result');
+      assert.notStrictEqual(
+        fn(desc, '1.2', uid, sourceContext, labels),
+        u1,
+        'changing the version should change the result');
+      assert.notStrictEqual(
+        fn(desc, version, '5', sourceContext, labels), u1,
+        'changing the description should change the result');
+      assert.notStrictEqual(
+        fn(desc, version, uid, { git: 'blah' }, labels),
+        u1,
+        'changing the sourceContext should change the result');
+      assert.notStrictEqual(
+        fn(desc, version, uid, sourceContext, { key1: 'value2' }),
+        u1,
+        'changing the labels should change the result');
+    });
+  });
 });


### PR DESCRIPTION
When sourceContext changed, our uniquifier wasn't because of a bug in how we were concatenating it.

Fixes: https://github.com/GoogleCloudPlatform/cloud-debug-nodejs/issues/263