### PR TITLE
Revert "Use service name as debuggee id on gke (#275)"

### DIFF
--- a/test/test-debuglet.js
+++ b/test/test-debuglet.js
@@ -295,28 +295,6 @@ describe('Debuglet', function() {
            assert.ok(_.isString(debuglet.config_.serviceContext.minorVersion_));
          });
 
-      it('should use GKE cluster name if available', function(done) {
-        var scope = nock('http://metadata.google.internal')
-          .get('/computeMetadata/v1/instance/attributes/cluster-name')
-            .once()
-            .reply(200, 'my-cool-cluster');
-        var debug = require('../src/debug.js')(
-          {projectId: 'fake-project', credentials: fakeCredentials});
-        var debuglet = new Debuglet(debug, defaultConfig);
-        debuglet.once('started', function(id) {
-          debuglet.stop();
-          assert.ok(debuglet.config_);
-          assert.ok(debuglet.config_.serviceContext);
-          assert.strictEqual(debuglet.config_.serviceContext.service,
-                           'my-cool-cluster');
-          assert.strictEqual(debuglet.config_.serviceContext.version,
-                           'unversioned');
-          scope.done();
-          done();
-        });
-        debuglet.start();
-      });
-
       it('should not have minorVersion unless enviroment provides it',
          function() {
            var debug = require('../src/debug.js')();


### PR DESCRIPTION
This reverts commit d3994f89599258d93c4d887ad5a605fb005ba168 as it breaks on non-GKE GCP enviornments.

See: https://github.com/GoogleCloudPlatform/cloud-debug-nodejs/pull/275#issuecomment-309308717