### PR TITLE
Fix the system tests

### DIFF
--- a/system-test/test-controller.js
+++ b/system-test/test-controller.js
@@ -28,7 +28,7 @@ assert.ok(
 
 var Controller = require('../src/controller.js').Controller;
 var Debuggee = require('../src/debuggee.js').Debuggee;
-var debug = require('../src/debug.js')();
+var debug = require('../src/debug.js').Debug();
 
 
 describe('Controller', function() {

--- a/system-test/test-e2e.js
+++ b/system-test/test-e2e.js
@@ -21,7 +21,7 @@ var _ = require('lodash'); // for _.find. Can't use ES6 yet.
 var cp = require('child_process');
 var semver = require('semver');
 var promisifyAll = require('@google-cloud/common').util.promisifyAll;
-var Debug = require('../src/debug.js');
+var Debug = require('../src/debug.js').Debug;
 var Debugger = require('../test/debugger.js');
 
 var CLUSTER_WORKERS = 3;


### PR DESCRIPTION
The changes to the source files as part of their conversion to
Typescript caused some of the `require` statements in the
system and end-to-end tests to be incorrect.  This addresses those
issues.