### PR TITLE
drop test dependency on proxyquire

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "merge2": "^1.0.3",
     "mocha": "^3.0.0",
     "nock": "^9.0.0",
-    "proxyquire": "^1.7.11",
     "request": "^2.81.0",
     "source-map-support": "^0.4.15",
     "tslint": "^5.4.3",
@@ -72,7 +71,7 @@
     "bump": "gulp && ./bin/run-bump.sh",
     "closure": "gulp && ./node_modules/.bin/closure-npc"
   },
-  "files":[
+  "files": [
     "CHANGELOG.md",
     "LICENSE",
     "README.md",

--- a/test/fixtures/fib.js
+++ b/test/fixtures/fib.js
@@ -21,10 +21,8 @@ function fib(n) {
  * limitations under the License.
  */
 
-var proxyquire = require('proxyquire');
-proxyquire('gcp-metadata', {
-  'retry-request': require('request')
-});
+const nocks = require('../nocks.js');
+nocks.projectId('fake-project-id');
 
 var debuglet = require('../..').start({
   debug: {

--- a/test/test-module.js
+++ b/test/test-module.js
@@ -19,11 +19,13 @@
 var assert = require('assert');
 var module = require('..');
 var nock = require('nock');
+var nocks = require('./nocks.js');
 
 nock.disableNetConnect();
 
 describe('Debug module', function() {
   before(function(done) {
+    nocks.projectId('project-via-metadata');
     var debuglet = module.start(
         {projectId: '0', debug: {forceNewAgent_: true, testMode_: true}});
     debuglet.on('started', function() {

--- a/test/test-options-credentials.js
+++ b/test/test-options-credentials.js
@@ -61,6 +61,7 @@ describe('test-options-credentials', function() {
       setImmediate(done);
       return true;
     });
+    nocks.projectId('project-via-metadata');
     debuglet = new Debuglet(debug, config);
     debuglet.start();
   });
@@ -83,6 +84,7 @@ describe('test-options-credentials', function() {
       setImmediate(done);
       return true;
     });
+    nocks.projectId('project-via-metadata');
     debuglet = new Debuglet(debug, config);
     debuglet.start();
   });
@@ -113,6 +115,7 @@ describe('test-options-credentials', function() {
       setImmediate(done);
       return true;
     });
+    nocks.projectId('project-via-metadata');
     ['client_id', 'client_secret', 'refresh_token'].forEach(function(field) {
       assert(fileCredentials.hasOwnProperty(field));
       assert(options.credentials.hasOwnProperty(field));


### PR DESCRIPTION
This fixes the test failures on windows. `proxyquire` has global side-effects and depending on the order in which files are loaded, we could get different behaviour. I've modified the tests so that they are less reliant on global behaviour.