### PR TITLE
Start using async/await to flatten the pyramid in Debuglet.start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -359,12 +359,6 @@
         }
       }
     },
-    "cli": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
-      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
-      "dev": true
-    },
     "cli-color": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.2.0.tgz",
@@ -448,12 +442,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc="
-    },
-    "console-browserify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "dev": true
     },
     "convert-source-map": {
       "version": "1.5.0",
@@ -552,12 +540,6 @@
         }
       }
     },
-    "date-now": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
-      "dev": true
-    },
     "dateformat": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
@@ -623,6 +605,11 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true
     },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ="
+    },
     "del": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
@@ -656,44 +643,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
       "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
-      "dev": true
-    },
-    "dom-serializer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
-      "dev": true,
-      "dependencies": {
-        "domelementtype": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-          "dev": true
-        },
-        "entities": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
-          "dev": true
-        }
-      }
-    },
-    "domelementtype": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
-      "dev": true
-    },
-    "domhandler": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
-      "dev": true
-    },
-    "domutils": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true
     },
     "duplexer": {
@@ -754,11 +703,15 @@
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
     },
-    "entities": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
-      "dev": true
+    "es-abstract": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
+      "integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw="
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0="
     },
     "es5-ext": {
       "version": "0.10.23",
@@ -842,12 +795,6 @@
           "dev": true
         }
       }
-    },
-    "exit": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-      "dev": true
     },
     "expand-brackets": {
       "version": "0.1.5",
@@ -968,6 +915,11 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true
     },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -995,6 +947,11 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
     },
     "gaze": {
       "version": "0.5.2",
@@ -1517,6 +1474,11 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
     },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg="
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -1550,32 +1512,6 @@
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true
-    },
-    "htmlparser2": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
-      "dev": true,
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
     },
     "http-signature": {
       "version": "1.1.1",
@@ -1653,6 +1589,16 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
       "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -1752,6 +1698,11 @@
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE="
+    },
     "is-relative": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
@@ -1768,6 +1719,11 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.3.tgz",
       "integrity": "sha1-oEc7Jnx1ZjVIa+7cfjNE5UnRUqw="
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1869,20 +1825,6 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
-    },
-    "jshint": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
-      "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
-      "dev": true,
-      "dependencies": {
-        "lodash": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
-          "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
-          "dev": true
-        }
-      }
     },
     "json-schema": {
       "version": "0.2.3",
@@ -2405,6 +2347,11 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+    },
     "object.defaults": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
@@ -2424,6 +2371,11 @@
           "dev": true
         }
       }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY="
     },
     "object.omit": {
       "version": "2.0.1",
@@ -2754,12 +2706,6 @@
       "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
       "dev": true
     },
-    "shelljs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
-      "dev": true
-    },
     "sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
@@ -2923,12 +2869,6 @@
       "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
       "dev": true
     },
-    "strip-json-comments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-      "dev": true
-    },
     "stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
@@ -3087,6 +3027,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "util.promisify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA=="
     },
     "uuid": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "lodash": "^4.12.0",
     "semver": "^5.1.0",
     "source-map": "^0.5.1",
-    "split": "^1.0.0"
+    "split": "^1.0.0",
+    "util.promisify": "^1.0.0"
   },
   "scripts": {
     "build": "gulp compile",

--- a/test/test-duplicate-expressions.js
+++ b/test/test-duplicate-expressions.js
@@ -52,20 +52,18 @@ describe(__filename, function() {
 
   beforeEach(function(done) {
     if (!api) {
-      scanner.scan(true, config.workingDirectory, /.js$/,
-        function(err, fileStats, hash) {
-        assert(!err);
+      scanner.scan(true, config.workingDirectory, /.js$/)
+        .then(function (fileStats) {
+          var jsStats = fileStats.selectStats(/.js$/);
+          var mapFiles = fileStats.selectFiles(/.map$/, process.cwd());
+          SourceMapper.create(mapFiles, function (err, mapper) {
+            assert(!err);
 
-        var jsStats = fileStats.selectStats(/.js$/);
-        var mapFiles = fileStats.selectFiles(/.map$/, process.cwd());
-        SourceMapper.create(mapFiles, function(err, mapper) {
-          assert(!err);
-
-          api = v8debugapi.create(logger, config, jsStats, mapper);
-          assert.ok(api, 'should be able to create the api');
-          done();
+            api = v8debugapi.create(logger, config, jsStats, mapper);
+            assert.ok(api, 'should be able to create the api');
+            done();
+          });
         });
-      });
     } else {
       assert(stateIsClean(api));
       done();

--- a/test/test-duplicate-nested-expressions.js
+++ b/test/test-duplicate-nested-expressions.js
@@ -50,20 +50,18 @@ describe(__filename, function() {
 
   beforeEach(function(done) {
     if (!api) {
-      scanner.scan(true, config.workingDirectory, /.js$/, 
-      function(err, fileStats, hash) {
-        assert(!err);
+      scanner.scan(true, config.workingDirectory, /.js$/)
+        .then(function (fileStats) {
+          var jsStats = fileStats.selectStats(/.js$/);
+          var mapFiles = fileStats.selectFiles(/.map$/, process.cwd());
+          SourceMapper.create(mapFiles, function (err, mapper) {
+            assert(!err);
 
-        var jsStats = fileStats.selectStats(/.js$/);
-        var mapFiles = fileStats.selectFiles(/.map$/, process.cwd());
-        SourceMapper.create(mapFiles, function(err, mapper) {
-          assert(!err);
-
-          api = v8debugapi.create(logger, config, jsStats, mapper);
-          assert.ok(api, 'should be able to create the api');
-          done();
+            api = v8debugapi.create(logger, config, jsStats, mapper);
+            assert.ok(api, 'should be able to create the api');
+            done();
+          });
         });
-      });
     } else {
       assert(stateIsClean(api));
       done();

--- a/test/test-fat-arrow.js
+++ b/test/test-fat-arrow.js
@@ -46,13 +46,11 @@ describe(__filename, function() {
   });
   beforeEach(function(done) {
     if (!api) {
-      scanner.scan(true, config.workingDirectory, /.js$/,
-        function(err, fileStats, hash) {
-          assert(!err);
-
+      scanner.scan(true, config.workingDirectory, /.js$/)
+        .then(function (fileStats) {
           var jsStats = fileStats.selectStats(/.js$/);
           var mapFiles = fileStats.selectFiles(/.map$/, process.cwd());
-          SourceMapper.create(mapFiles, function(err, mapper) {
+          SourceMapper.create(mapFiles, function (err, mapper) {
             api = v8debugapi.create(logger, config, jsStats, mapper);
             assert.ok(api, 'should be able to create the api');
             done();

--- a/test/test-max-data-size.js
+++ b/test/test-max-data-size.js
@@ -43,19 +43,17 @@ describe('maxDataSize', function() {
   before(function(done) {
     if (!api) {
       var logger = common.logger({ logLevel: config.logLevel });
-      scanner.scan(true, config.workingDirectory, /.js$/,
-      function(err, fileStats, hash) {
-        assert(!err);
+      scanner.scan(true, config.workingDirectory, /.js$/)
+        .then(function (fileStats) {
+          var jsStats = fileStats.selectStats(/.js$/);
+          var mapFiles = fileStats.selectFiles(/.map$/, process.cwd());
+          SourceMapper.create(mapFiles, function (err, mapper) {
+            assert(!err);
 
-        var jsStats = fileStats.selectStats(/.js$/);
-        var mapFiles = fileStats.selectFiles(/.map$/, process.cwd());
-        SourceMapper.create(mapFiles, function(err, mapper) {
-          assert(!err);
-
-          api = v8debugapi.create(logger, config, jsStats, mapper);
-          done();
+            api = v8debugapi.create(logger, config, jsStats, mapper);
+            done();
+          });
         });
-      });
     } else {
       done();
     }

--- a/test/test-scanner.js
+++ b/test/test-scanner.js
@@ -30,42 +30,37 @@ describe('scanner', function() {
 
   describe('scan', function() {
     it('should complain when called without a path', function(done) {
-      scanner.scan(true, null, /.js$/, function(err) {
-        assert.ok(err);
+      scanner.scan(true, null, /.js$/).catch(() => {
         done();
       });
     });
 
     it('should error when called on a bad path', function(done) {
-      scanner.scan(true, './this directory does not exist', /.js$/, 
-        function(err) {
-          assert(err);
-          done();
-        });
+      scanner.scan(true, './this directory does not exist', /.js$/).catch((err) => {
+        done();
+      }); 
     });
 
     it('should be able to return all file stats directly', function(done) {
-      scanner.scan(true, fixture('coffee'), /.*$/, function(err, fileStats, hash) {
+      scanner.scan(true, fixture('coffee'), /.*$/)
+      .then((fileStats) => {
         var files = Object.keys(fileStats.all());
-        assert.ifError(err);
         assert.strictEqual(files.length, 3);
         done();
       });
     });
 
     it('should be able to filter to return all file stats', function(done) {
-      scanner.scan(true, fixture('coffee'), /.*$/, function(err, fileStats, hash) {
+      scanner.scan(true, fixture('coffee'), /.*$/).then(function(fileStats) {
         var files = fileStats.selectFiles(/.*$/, '');
-        assert.ifError(err);
         assert.strictEqual(files.length, 3);
         done();
       });
     });
 
     it('should be able to filter filenames', function(done) {
-      scanner.scan(true, fixture('coffee'), /.*$/, function(err, fileStats, hash) {
+      scanner.scan(true, fixture('coffee'), /.*$/).then(function(fileStats) {
         var files = fileStats.selectFiles(/.js$/);
-        assert.ifError(err);
         assert.strictEqual(files.length, 1);
         assert.ok(files[0], path.join(fixtureDir, 'coffee', 'transpile.js'));
         done();
@@ -73,10 +68,8 @@ describe('scanner', function() {
     });
 
     it('should be able to filter file stats', function(done) {
-      scanner.scan(true, fixture('coffee'), /.*$/, function(err, fileStats, hash) {
+      scanner.scan(true, fixture('coffee'), /.*$/).then(function(fileStats) {
         var stats = fileStats.selectStats(/.js$/);
-        assert.ifError(err);
-
         var keys = Object.keys(stats);
         assert.strictEqual(keys.length, 1);
 
@@ -89,14 +82,12 @@ describe('scanner', function() {
 
     it('should return the same hash if the files don\'t change',
      function(done) {
-       scanner.scan(true, process.cwd(), /.js$/, function(err1, filesStats1, hash1) {
-         var files1 = Object.keys(filesStats1.all());
-         assert.ifError(err1);
-         scanner.scan(true, process.cwd(), /.js$/, function(err2, filesStats2, hash2) {
-          var files2 = Object.keys(filesStats2.all());
-          assert.ifError(err2);
+       scanner.scan(true, process.cwd(), /.js$/).then(function(fileStats1) {
+         var files1 = Object.keys(fileStats1.all());
+         scanner.scan(true, process.cwd(), /.js$/).then(function(fileStats2) {
+          var files2 = Object.keys(fileStats2.all());
           assert.deepEqual(files1.sort(), files2.sort());
-          assert.strictEqual(hash1, hash2);
+          assert.strictEqual(fileStats1.hash, fileStats2.hash);
           done();
          });
        });
@@ -104,18 +95,16 @@ describe('scanner', function() {
 
     it('should return undefined hash if shouldHash is false',
      function(done) {
-       scanner.scan(false, process.cwd(), /.js$/, function(err, filesStats, hash) {
-         assert.ifError(err);
-         assert(!hash);
+       scanner.scan(false, process.cwd(), /.js$/).then(function(fileStats) {
+         assert(!fileStats.hash);
          done();
        });
     });
 
     it('should work with relative paths', function(done) {
-      scanner.scan(true, fixtureDir, /.js$/, function(err, fileStats, hash) {
+      scanner.scan(true, fixtureDir, /.js$/).then(function(fileStats) {
         var files = Object.keys(fileStats.all());
-        assert.ifError(err);
-        assert.ok(hash);
+        assert.ok(fileStats.hash);
         assert.ok(files.length !== 0);
         done();
       });
@@ -123,10 +112,9 @@ describe('scanner', function() {
 
     it('should return a valid hash even when there are no javascript files',
       function(done) {
-        scanner.scan(true, fixture('nojs'), /.js$/, function(err, fileStats, hash) {
+        scanner.scan(true, fixture('nojs'), /.js$/).then(function(fileStats) {
           var files = Object.keys(fileStats.all());
-          assert.ifError(err);
-          assert.ok(hash);
+          assert.ok(fileStats.hash);
           assert.ok(files.length === 0);
           done();
         });
@@ -135,16 +123,14 @@ describe('scanner', function() {
     it('should return a different hash if the files contents change',
       function(done) {
         fs.writeFileSync(fixture('tmp.js'), '1 + 1');
-        scanner.scan(true, fixtureDir, /.js$/, function(err1, filesStats1, hash1) {
-          var files1 = Object.keys(filesStats1.all());
-          assert.ifError(err1);
-          assert.ok(hash1);
+        scanner.scan(true, fixtureDir, /.js$/).then(function(fileStats1) {
+          var files1 = Object.keys(fileStats1.all());
+          assert.ok(fileStats1.hash);
           fs.writeFileSync(fixture('tmp.js'), '1 + 2');
-          scanner.scan(true, fixtureDir, /.js$/, function(err2, filesStats2, hash2) {
-            var files2 = Object.keys(filesStats2.all());
-            assert.ifError(err2);
-            assert.ok(hash2);
-            assert.notStrictEqual(hash1, hash2);
+          scanner.scan(true, fixtureDir, /.js$/).then(function(fileStats2) {
+            var files2 = Object.keys(fileStats2.all());
+            assert.ok(fileStats2.hash);
+            assert.notStrictEqual(fileStats1.hash, fileStats2.hash);
             assert.deepEqual(files1.sort(), files2.sort());
             fs.unlinkSync(fixture('tmp.js'));
             done();
@@ -154,23 +140,20 @@ describe('scanner', function() {
 
     it('should return an updated file list when file list changes',
       function(done) {
-        scanner.scan(true, fixtureDir, /.js$/, function(err1, fileStats1, hash1) {
+        scanner.scan(true, fixtureDir, /.js$/).then(function(fileStats1) {
           var files1 = Object.keys(fileStats1.all());
-          assert.ifError(err1);
-          assert.ok(hash1);
+          assert.ok(fileStats1.hash);
           fs.writeFileSync(fixture('tmp.js'), ''); // empty.
-          scanner.scan(true, fixtureDir, /.js$/, function(err2, fileStats2, hash2) {
+          scanner.scan(true, fixtureDir, /.js$/).then(function(fileStats2) {
             var files2 = Object.keys(fileStats2.all());
-            assert.ifError(err2);
-            assert.ok(hash2);
-            assert.notStrictEqual(hash1, hash2);
+            assert.ok(fileStats2.hash);
+            assert.notStrictEqual(fileStats1.hash, fileStats2.hash);
             assert.ok(files1.length === files2.length - 1);
             fs.unlinkSync(fixture('tmp.js'));
-            scanner.scan(true, fixtureDir, /.js$/, function(err3, fileStats3, hash3) {
+            scanner.scan(true, fixtureDir, /.js$/).then(function(fileStats3) {
               var files3 = Object.keys(fileStats3.all());
-              assert.ifError(err3);
-              assert.ok(hash3);
-              assert.strictEqual(hash1, hash3);
+              assert.ok(fileStats2.hash);
+              assert.strictEqual(fileStats1.hash, fileStats3.hash);
               assert.deepEqual(files1.sort(), files3.sort());
               done();
             });

--- a/test/test-this-context.js
+++ b/test/test-this-context.js
@@ -50,20 +50,18 @@ describe(__filename, function() {
 
   beforeEach(function(done) {
     if (!api) {
-      scanner.scan(true, config.workingDirectory, /.js$/,
-      function(err, fileStats, hash) {
-        assert(!err);
+      scanner.scan(true, config.workingDirectory, /.js$/)
+        .then(function (fileStats) {
+          var jsStats = fileStats.selectStats(/.js$/);
+          var mapFiles = fileStats.selectFiles(/.map$/, process.cwd());
+          SourceMapper.create(mapFiles, function (err, mapper) {
+            assert(!err);
 
-        var jsStats = fileStats.selectStats(/.js$/);
-        var mapFiles = fileStats.selectFiles(/.map$/, process.cwd());
-        SourceMapper.create(mapFiles, function(err, mapper) {
-          assert(!err);
-
-          api = v8debugapi.create(logger, config, jsStats, mapper);
-          assert.ok(api, 'should be able to create the api');
-          done();
+            api = v8debugapi.create(logger, config, jsStats, mapper);
+            assert.ok(api, 'should be able to create the api');
+            done();
+          });
         });
-      });
     } else {
       assert(stateIsClean(api));
       done();

--- a/test/test-try-catch.js
+++ b/test/test-try-catch.js
@@ -50,20 +50,18 @@ describe(__filename, function() {
 
   beforeEach(function(done) {
     if (!api) {
-      scanner.scan(true, config.workingDirectory, /.js$/,
-      function(err, fileStats, hash) {
-        assert(!err);
+      scanner.scan(true, config.workingDirectory, /.js$/)
+        .then(function (fileStats) {
+          var jsStats = fileStats.selectStats(/.js$/);
+          var mapFiles = fileStats.selectFiles(/.map$/, process.cwd());
+          SourceMapper.create(mapFiles, function (err, mapper) {
+            assert(!err);
 
-        var jsStats = fileStats.selectStats(/.js$/);
-        var mapFiles = fileStats.selectFiles(/.map$/, process.cwd());
-        SourceMapper.create(mapFiles, function(err, mapper) {
-          assert(!err);
-
-          api = v8debugapi.create(logger, config, jsStats, mapper);
-          assert.ok(api, 'should be able to create the api');
-          done();
+            api = v8debugapi.create(logger, config, jsStats, mapper);
+            assert.ok(api, 'should be able to create the api');
+            done();
+          });
         });
-      });
     } else {
       assert(stateIsClean(api));
       done();


### PR DESCRIPTION
Start using async/await to simplify Debuglet.start. This exercise can be continued for the remainder of the nested callbacks in follow-on PRs. This PR peels the first two layers only.

For an easier time reviewing, review each commit individually.