### PR TITLE
Change v8debugAPI clear to async.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
       "integrity": "sha512-vm5OGsKc61Sx/GTRMQ9d0H0PYCDebT78/bdIBPCoPEHdgp0etaH1RzMmkDygymUmyXTj3rdWQn0sRUpYKZzljA==",
       "dev": true,
       "requires": {
-        "@types/node": "7.0.33"
+        "@types/node": "8.0.27"
       }
     },
     "@types/lodash": {
@@ -106,13 +106,13 @@
       "integrity": "sha1-H75b3suUPBCad4VT+k0kAcuTlLQ=",
       "dev": true,
       "requires": {
-        "@types/node": "7.0.33"
+        "@types/node": "8.0.27"
       }
     },
     "@types/node": {
-      "version": "7.0.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.33.tgz",
-      "integrity": "sha512-8fVvl6Yyk3jZvSYxRMS9/AmZJ5RXCOP9N4xSlykyBViVESu751pxHYTN14Embn1Fem78YwEHdC7p7KGQQpwunw==",
+      "version": "8.0.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.27.tgz",
+      "integrity": "sha512-MiOd5TB6ftlOw6gLY3XdF0s/9YoTo172A6qGzi5I1SJy2dRZqg/LAHGTJMm1XFWx7kuYkbVW0sp/z3OP7VnkjQ==",
       "dev": true
     },
     "@types/request": {
@@ -122,7 +122,7 @@
       "dev": true,
       "requires": {
         "@types/form-data": "2.2.0",
-        "@types/node": "7.0.33"
+        "@types/node": "8.0.27"
       }
     },
     "@types/semver": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/lodash": "^4.14.69",
     "@types/mocha": "^2.2.41",
     "@types/nock": "^8.2.1",
-    "@types/node": "^7.0.18",
+    "@types/node": "^8.0.27",
     "@types/request": "^2.0.0",
     "@types/semver": "^5.3.32",
     "@types/source-map": "^0.5.0",

--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -660,11 +660,14 @@ export class Debuglet extends EventEmitter {
    * @private
    */
   removeBreakpoint_(breakpoint: Breakpoint): void {
+    const that = this;
     this.logger_.info('\tdeleted breakpoint', breakpoint.id);
     // TODO: Address the case when `breakpoint.id` is `undefined`.
     delete this.activeBreakpointMap_[breakpoint.id as string];
     if (this.v8debug_) {
-      this.v8debug_.clear(breakpoint);
+      this.v8debug_.clear(breakpoint, function(err) {
+        if (err) that.logger_.error(err);
+      });
     }
   }
 

--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -660,13 +660,12 @@ export class Debuglet extends EventEmitter {
    * @private
    */
   removeBreakpoint_(breakpoint: Breakpoint): void {
-    const that = this;
     this.logger_.info('\tdeleted breakpoint', breakpoint.id);
     // TODO: Address the case when `breakpoint.id` is `undefined`.
     delete this.activeBreakpointMap_[breakpoint.id as string];
     if (this.v8debug_) {
-      this.v8debug_.clear(breakpoint, function(err) {
-        if (err) that.logger_.error(err);
+      this.v8debug_.clear(breakpoint, (err) => {
+        if (err) this.logger_.error(err);
       });
     }
   }

--- a/src/agent/state.ts
+++ b/src/agent/state.ts
@@ -32,7 +32,7 @@ import {DebugAgentConfig} from './config';
 // TODO: Determine if `ScopeType` should be named `scopeType`.
 // tslint:disable-next-line:variable-name
 const ScopeType = vm.runInDebugContext('ScopeType');
-const assert = debugAssert(process.env.CLOUD_DEBUG_ASSERTIONS);
+const assert = debugAssert(!!process.env.CLOUD_DEBUG_ASSERTIONS);
 
 // Error message indices into the resolved variable table.
 const BUFFER_FULL_MESSAGE_INDEX = 0;

--- a/src/agent/v8debugapi.ts
+++ b/src/agent/v8debugapi.ts
@@ -37,7 +37,7 @@ const messages = {
       'A script matching the source file was not found loaded on the debuggee',
   SOURCE_FILE_AMBIGUOUS: 'Multiple files match the path specified',
   V8_BREAKPOINT_ERROR: 'Unable to set breakpoint in v8',
-  V8_BREAKPOINT_CLAER_ERROR: 'Unable to clear breakpoint in v8',
+  V8_BREAKPOINT_CLEAR_ERROR: 'Unable to clear breakpoint in v8',
   SYNTAX_ERROR_IN_CONDITION: 'Syntax error in condition: ',
   ERROR_EVALUATING_CONDITION: 'Error evaluating condition: ',
   ERROR_COMPILING_CONDITION: 'Error compiling condition.',
@@ -196,13 +196,13 @@ export function create(
       if (typeof breakpoint.id === 'undefined') {
         return setErrorStatusAndCallback(
             cb, breakpoint, StatusMessage.BREAKPOINT_CONDITION,
-            messages.V8_BREAKPOINT_CLAER_ERROR);
+            messages.V8_BREAKPOINT_CLEAR_ERROR);
       }
       const breakpointData = breakpoints[breakpoint.id];
       if (!breakpointData) {
         return setErrorStatusAndCallback(
             cb, breakpoint, StatusMessage.BREAKPOINT_CONDITION,
-            messages.V8_BREAKPOINT_CLAER_ERROR);
+            messages.V8_BREAKPOINT_CLEAR_ERROR);
       }
       const v8bp = breakpointData.v8Breakpoint;
 

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -289,7 +289,7 @@ describe('Debuglet', function() {
   });
 
   describe('setup', function() {
-    before(function() { oldGP = process.env.GCLOUD_PROJECT; });
+    before(function() { oldGP = String(process.env.GCLOUD_PROJECT); });
 
     after(function() { process.env.GCLOUD_PROJECT = oldGP; });
 
@@ -436,7 +436,7 @@ describe('Debuglet', function() {
 
       it('should respect GCLOUD_DEBUG_LOGLEVEL', function(done) {
         process.env.GCLOUD_PROJECT = '11020304f2934';
-        process.env.GCLOUD_DEBUG_LOGLEVEL = 3;
+        process.env.GCLOUD_DEBUG_LOGLEVEL = '3';
         const debug = new Debug({credentials: fakeCredentials});
         const debuglet = new Debuglet(debug, defaultConfig);
 

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -45,7 +45,7 @@ nock.disableNetConnect();
 
 const defaultConfig = extend(true, {}, DEFAULT_CONFIG, {logLevel: 0});
 
-let oldGP: string;
+let oldGP: string|undefined;
 
 declare type MetadataCallback = (err: Error|null, ob?: any, result?: string) => void;
 
@@ -289,7 +289,7 @@ describe('Debuglet', function() {
   });
 
   describe('setup', function() {
-    before(function() { oldGP = String(process.env.GCLOUD_PROJECT); });
+    before(function() { oldGP = process.env.GCLOUD_PROJECT; });
 
     after(function() { process.env.GCLOUD_PROJECT = oldGP; });
 

--- a/test/test-duplicate-expressions.ts
+++ b/test/test-duplicate-expressions.ts
@@ -89,8 +89,10 @@ describe(__filename, function() {
           assert.equal(varTableIndicesSeen.indexOf(expr.varTableIndex as number), -1);
           varTableIndicesSeen.push(expr.varTableIndex as number);
         });
-        api.clear(breakpointInFoo);
-        done();
+        api.clear(breakpointInFoo, function(err) {
+          assert.ifError(err);
+          done();
+        });
       });
       process.nextTick(foo);
     });

--- a/test/test-duplicate-nested-expressions.ts
+++ b/test/test-duplicate-nested-expressions.ts
@@ -88,8 +88,10 @@ describe(__filename, function() {
           locals[0],
           {name: 'a', value: 'test'}
  	      );
-        api.clear(brk);
-        done();
+        api.clear(brk,function(err) {
+          assert.ifError(err);
+          done();
+        })
       });
       process.nextTick(foo.bind(null, 'test'));
     });
@@ -115,8 +117,10 @@ describe(__filename, function() {
           locals[0],
           {name: 'a', value: '10'}
         );
-        api.clear(brk);
-        done();
+        api.clear(brk, function(err) {
+          assert.ifError(err);
+          done();
+        });
       });
       process.nextTick(foo.bind(null, 'test'));
     });
@@ -142,8 +146,10 @@ describe(__filename, function() {
           locals[0],
           {name: 'a', value: '11'}
         );
-        api.clear(brk);
-        done();
+        api.clear(brk, function(err) {
+          assert.ifError(err);
+          done();
+        });
       });
       process.nextTick(foo.bind(null, 'test'));
     });
@@ -173,8 +179,10 @@ describe(__filename, function() {
           locals[1],
           {name: 'a', value: 'true'}
         );
-        api.clear(brk);
-        done();
+        api.clear(brk, function(err) {
+          assert.ifError(err);
+          done();
+        });
       });
       process.nextTick(foo.bind(null, 'test'));
     });

--- a/test/test-fat-arrow.ts
+++ b/test/test-fat-arrow.ts
@@ -26,7 +26,7 @@ import defaultConfig from '../src/agent/config';
 import * as SourceMapper from '../src/agent/sourcemapper';
 import * as scanner from '../src/agent/scanner';
 
-process.env.GCLOUD_PROJECT = 0;
+process.env.GCLOUD_PROJECT = '0';
 
 function stateIsClean(api: V8DebugApi): boolean {
   assert.equal(api.numBreakpoints_(), 0,
@@ -89,8 +89,10 @@ describe(__filename, function() {
           locals[0],
           {name: 'b', value: '1'}
         );
-        api.clear(brk);
-        done();
+        api.clear(brk, function(err) {
+          assert.ifError(err);
+          done();
+        });
       });
       process.nextTick(foo.bind(null, 'test'));
     });
@@ -115,8 +117,10 @@ describe(__filename, function() {
           locals[0],
           {name: 'b', value: '2'}
         );
-        api.clear(brk);
-        done();
+        api.clear(brk, function(err) {
+          assert.ifError(err);
+          done();
+        });
       });
       process.nextTick(foo.bind(null, 'test'));
     });

--- a/test/test-this-context.ts
+++ b/test/test-this-context.ts
@@ -85,15 +85,17 @@ describe(__filename, function() {
         // TODO: Determine how to remove these casts to any.
         ctxMembers = (brk as any).variableTable.slice((brk as any).variableTable.length-1)[0]
           .members;
-        assert.deepEqual(ctxMembers.length, 1, 
+        assert.deepEqual(ctxMembers.length, 1,
           'There should be one member in the context variable value');
         assert.deepEqual(ctxMembers[0], {name: 'a', value: '10'});
         assert.equal(args.length, 0, 'There should be zero arguments');
         assert.equal(locals.length, 2, 'There should be two locals');
         assert.deepEqual(locals[0], {name: 'b', value: '1'});
         assert.deepEqual(locals[1].name, 'context');
-        api.clear(brk);
-        done();
+        api.clear(brk, function(err) {
+          assert.ifError(err);
+          done();
+        });
       });
       process.nextTick(code.foo.bind({}, 1));
     });
@@ -115,8 +117,10 @@ describe(__filename, function() {
         assert.equal(args.length, 0, 'There should be zero arguments');
         assert.equal(locals.length, 1, 'There should be one local');
         assert.deepEqual(locals[0], {name: 'j', value: '1'});
-        api.clear(brk);
-        done();
+        api.clear(brk, function(err) {
+          assert.ifError(err);
+          done();
+        });
       });
       process.nextTick(code.bar.bind(null, 1));
     });

--- a/test/test-try-catch.ts
+++ b/test/test-try-catch.ts
@@ -86,9 +86,11 @@ describe(__filename, function() {
         const e = locals[0];
         assert(e.name === 'e');
         assert(Number.isInteger(e.varTableIndex));
-        assert.equal(args.length, 0, 'There should be zero arguments');     
-        api.clear(brk);
-        done();
+        assert.equal(args.length, 0, 'There should be zero arguments');
+        api.clear(brk, function(err) {
+          assert.ifError(err);
+          done();
+        });
       });
       process.nextTick(foo.bind(null, 'test'));
     });
@@ -114,8 +116,10 @@ describe(__filename, function() {
           {name: 'e', value: '2'}
         );
         assert.equal(args.length, 0, 'There should be zero arguments');
-        api.clear(brk);
-        done();
+        api.clear(brk, function(err) {
+          assert.ifError(err);
+          done();
+        });
       });
       process.nextTick(foo.bind(null, 'test'));
     });

--- a/test/test-v8debugapi.ts
+++ b/test/test-v8debugapi.ts
@@ -305,8 +305,8 @@ describe('v8debugapi', function() {
           } as any as apiTypes.Breakpoint;
           api.set(bp, function(err) {
             test(err);
-            api.clear(bp, function(err1) {
-              test(err1);
+            api.clear(bp, function(err) {
+              test(err);
               done();
             });
           });
@@ -611,8 +611,8 @@ describe('v8debugapi', function() {
           assert(((localsVal as any).status as any).description.format.match(
             'Locals and arguments are only displayed.*config.capture.maxExpandFrames=0'
             ));
-          config.capture.maxExpandFrames = oldCount;
           api.clear(bp, function(err) {
+            config.capture.maxExpandFrames = oldCount;
             assert.ifError(err);
             done();
           });
@@ -638,8 +638,8 @@ describe('v8debugapi', function() {
           assert.equal(topFrame['function'], 'foo');
           assert.equal(topFrame.locals[0].name, 'n');
           assert.equal(topFrame.locals[0].value, '2');
-          config.capture.maxFrames = oldMax;
           api.clear(bp, function(err) {
+            config.capture.maxFrames = oldMax;
             assert.ifError(err);
             done();
           });
@@ -696,12 +696,12 @@ describe('v8debugapi', function() {
             return m.name === 'versions' && m.varTableIndex;
           } as any));
 
-          config.capture.maxDataSize = oldMaxData;
-          config.capture.maxProperties = oldMaxProps;
           api.clear(bp, function(err) {
+            config.capture.maxDataSize = oldMaxData;
+            config.capture.maxProperties = oldMaxProps;
             assert.ifError(err);
-            done();
-          });
+              done();
+            });
         });
         process.nextTick(function() {code.foo(3);});
       });
@@ -751,8 +751,8 @@ describe('v8debugapi', function() {
             return resolved && (resolved.status as any).isError;
           }));
 
-          config.capture.maxDataSize = oldMaxData;
           api.clear(bp, function(err) {
+            config.capture.maxDataSize = oldMaxData;
             assert.ifError(err);
             done();
           });
@@ -834,9 +834,9 @@ describe('v8debugapi', function() {
           const item = stringItems[0];
           assert(item.status.description.format.match(
             'Only first.*config.capture.maxStringLength=3.*of length 11.'));
-          config.capture.maxDataSize = oldMaxData;
-          config.capture.maxStringLength = oldMaxLength;
           api.clear(bp, function(err) {
+            config.capture.maxDataSize = oldMaxData;
+            config.capture.maxStringLength = oldMaxLength;
             assert.ifError(err);
             done();
           });
@@ -871,8 +871,8 @@ describe('v8debugapi', function() {
           assert((aVal as any).members[1].name.match(
             'Only first.*config.capture.maxProperties=1'));
 
-          config.capture.maxProperties = oldMax;
           api.clear(bp, function(err) {
+            config.capture.maxProperties = oldMax;
             assert.ifError(err);
             done();
           });
@@ -906,8 +906,8 @@ describe('v8debugapi', function() {
           assert((bVal as any).members[1].name.match(
             'Only first.*config.capture.maxProperties=1'));
 
-          config.capture.maxProperties = oldMax;
           api.clear(bp, function(err) {
+            config.capture.maxProperties = oldMax;
             assert.ifError(err);
             done();
           });
@@ -947,9 +947,9 @@ describe('v8debugapi', function() {
           // resulting in stringItems.length being 0.
           assert(stringItems.length === 1);
 
-          config.capture.maxDataSize = oldMaxData;
-          config.capture.maxStringLength = oldMaxLength;
           api.clear(bp, function(err) {
+            config.capture.maxDataSize = oldMaxData;
+            config.capture.maxStringLength = oldMaxLength;
             assert.ifError(err);
             done();
           });
@@ -986,9 +986,9 @@ describe('v8debugapi', function() {
             assert.equal(((fooVal as any).members as any).length, 4);
             assert.strictEqual((foo as any).status, undefined);
 
-            config.capture.maxDataSize = oldMaxData;
-            config.capture.maxProperties = oldMaxProps;
             api.clear(bp, function(err) {
+              config.capture.maxDataSize = oldMaxData;
+              config.capture.maxProperties = oldMaxProps;
               assert.ifError(err);
               done();
             });
@@ -1024,9 +1024,9 @@ describe('v8debugapi', function() {
             assert.equal(((fooVal as any).members as any).length, 3);
             assert.strictEqual((foo as any).status, undefined);
 
-            config.capture.maxDataSize = oldMaxData;
-            config.capture.maxProperties = oldMaxProps;
             api.clear(bp, function(err) {
+              config.capture.maxDataSize = oldMaxData;
+              config.capture.maxProperties = oldMaxProps;
               assert.ifError(err);
               done();
             });
@@ -1063,9 +1063,9 @@ describe('v8debugapi', function() {
               'Max data size reached'));
             assert(((fooVal as any).status as any).isError);
 
-            config.capture.maxDataSize = oldMaxData;
-            config.capture.maxProperties = oldMaxProps;
             api.clear(bp, function(err) {
+              config.capture.maxDataSize = oldMaxData;
+              config.capture.maxProperties = oldMaxProps;
               assert.ifError(err);
               done();
             });
@@ -1102,9 +1102,9 @@ describe('v8debugapi', function() {
               'Max data size reached'));
             assert(((fooVal as any).status as any).isError);
 
-            config.capture.maxDataSize = oldMaxData;
-            config.capture.maxProperties = oldMaxProps;
             api.clear(bp, function(err) {
+              config.capture.maxDataSize = oldMaxData;
+              config.capture.maxProperties = oldMaxProps;
               assert.ifError(err);
               done();
             });
@@ -1145,9 +1145,9 @@ describe('v8debugapi', function() {
               'Max data size reached'));
             assert((bArray.status as any).isError);
 
-            config.capture.maxDataSize = oldMaxData;
-            config.capture.maxProperties = oldMaxProps;
             api.clear(bp, function(err) {
+              config.capture.maxDataSize = oldMaxData;
+              config.capture.maxProperties = oldMaxProps;
               assert.ifError(err);
               done();
             });

--- a/test/test-v8debugapi.ts
+++ b/test/test-v8debugapi.ts
@@ -160,8 +160,10 @@ describe('v8debugapi', function() {
     api.set(bp, function(err) {
       assert.ifError(err);
       assert.equal(api.numBreakpoints_(), 1);
-      api.clear(bp);
-      done();
+      api.clear(bp, function(err) {
+        assert.ifError(err);
+        done();
+      });
     });
   });
 
@@ -171,8 +173,10 @@ describe('v8debugapi', function() {
       const bp: apiTypes.Breakpoint = { id: 0, location: breakpointInFoo.location} as any as apiTypes.Breakpoint;
       api.set(bp, function(err) {
         assert.ifError(err);
-        api.clear(bp);
-        done();
+        api.clear(bp, function(err) {
+          assert.ifError(err);
+          done();
+        });
       });
     });
 
@@ -202,8 +206,10 @@ describe('v8debugapi', function() {
         'foo.js')}} as any as apiTypes.Breakpoint;
       api.set(bp, function(err) {
         assert.ifError(err);
-        api.clear(bp);
-        done();
+        api.clear(bp, function(err) {
+          assert.ifError(err);
+          done();
+        });
       });
     });
 
@@ -216,8 +222,10 @@ describe('v8debugapi', function() {
         'a', 'hello.js')}} as any as apiTypes.Breakpoint;
       api.set(bp, function(err) {
         assert.ifError(err);
-        api.clear(bp);
-        done();
+        api.clear(bp, function(err) {
+          assert.ifError(err);
+          done();
+        });
       });
     });
 
@@ -297,8 +305,10 @@ describe('v8debugapi', function() {
           } as any as apiTypes.Breakpoint;
           api.set(bp, function(err) {
             test(err);
-            api.clear(bp);
-            done();
+            api.clear(bp, function(err1) {
+              test(err1);
+              done();
+            });
           });
         });
       });
@@ -409,8 +419,10 @@ describe('v8debugapi', function() {
           assert.ifError(err);
           api.wait(bp, function(err) {
             assert.ifError(err);
-            api.clear(bp);
-            done();
+            api.clear(bp, function(err) {
+              assert.ifError(err);
+              done();
+            });
           });
           process.nextTick(function() {code.foo(7);});
         });
@@ -459,8 +471,10 @@ describe('v8debugapi', function() {
           assert.equal(transcript, 'catcat');
           assert(runCount > 12);
           clearInterval(interval);
-          api.clear(bp);
-          done();
+          api.clear(bp, function(err) {
+            assert.ifError(err);
+            done();
+          });
         }, 1500);
       });
     });
@@ -476,8 +490,10 @@ describe('v8debugapi', function() {
         assert.ifError(err);
         api.wait(bp, function(err) {
           assert.ifError(err);
-          api.clear(bp);
-          done();
+          api.clear(bp, function(err) {
+            assert.ifError(err);
+            done();
+          });
         });
         process.nextTick(function() {code.foo(1);});
       });
@@ -499,8 +515,10 @@ describe('v8debugapi', function() {
           setTimeout(function() {
             logger.warn = oldWarn;
             assert.equal(logCount, 0);
-            api.clear(bp);
-            done();
+            api.clear(bp, function(err) {
+              assert.ifError(err);
+              done();
+            });
           }, 100);
         });
         process.nextTick(function() {code.foo(1);});
@@ -521,8 +539,10 @@ describe('v8debugapi', function() {
         assert.ifError(err);
         api.wait(bp, function(err) {
           assert.ifError(err);
-          api.clear(bp);
-          done();
+          api.clear(bp, function(err) {
+            assert.ifError(err);
+            done();
+          });
         });
         process.nextTick(function() {code.foo(1);});
       });
@@ -547,8 +567,10 @@ describe('v8debugapi', function() {
           assert.equal(topFrame.locals[0].value, '2');
           assert.equal(topFrame.locals[1].name, 'A');
           assert.equal(topFrame.locals[2].name, 'B');
-          api.clear(bp);
-          done();
+          api.clear(bp, function(err) {
+            assert.ifError(err);
+            done();
+          });
         });
       process.nextTick(function() {code.foo(2);});
       });
@@ -589,9 +611,11 @@ describe('v8debugapi', function() {
           assert(((localsVal as any).status as any).description.format.match(
             'Locals and arguments are only displayed.*config.capture.maxExpandFrames=0'
             ));
-          api.clear(bp);
           config.capture.maxExpandFrames = oldCount;
-          done();
+          api.clear(bp, function(err) {
+            assert.ifError(err);
+            done();
+          });
         });
       process.nextTick(function() {code.foo(2);});
       });
@@ -614,9 +638,11 @@ describe('v8debugapi', function() {
           assert.equal(topFrame['function'], 'foo');
           assert.equal(topFrame.locals[0].name, 'n');
           assert.equal(topFrame.locals[0].value, '2');
-          api.clear(bp);
           config.capture.maxFrames = oldMax;
-          done();
+          api.clear(bp, function(err) {
+            assert.ifError(err);
+            done();
+          });
         });
       process.nextTick(function() {code.foo(2);});
       });
@@ -670,10 +696,12 @@ describe('v8debugapi', function() {
             return m.name === 'versions' && m.varTableIndex;
           } as any));
 
-          api.clear(bp);
           config.capture.maxDataSize = oldMaxData;
           config.capture.maxProperties = oldMaxProps;
-          done();
+          api.clear(bp, function(err) {
+            assert.ifError(err);
+            done();
+          });
         });
         process.nextTick(function() {code.foo(3);});
       });
@@ -723,9 +751,11 @@ describe('v8debugapi', function() {
             return resolved && (resolved.status as any).isError;
           }));
 
-          api.clear(bp);
           config.capture.maxDataSize = oldMaxData;
-          done();
+          api.clear(bp, function(err) {
+            assert.ifError(err);
+            done();
+          });
         });
         process.nextTick(function() {code.getterObject();});
       });
@@ -763,8 +793,10 @@ describe('v8debugapi', function() {
           });
           assert(found);
 
-          api.clear(bp);
-          done();
+          api.clear(bp, function(err) {
+            assert.ifError(err);
+            done();
+          });
         });
         process.nextTick(function() {code.foo();});
       });
@@ -802,10 +834,12 @@ describe('v8debugapi', function() {
           const item = stringItems[0];
           assert(item.status.description.format.match(
             'Only first.*config.capture.maxStringLength=3.*of length 11.'));
-          api.clear(bp);
           config.capture.maxDataSize = oldMaxData;
           config.capture.maxStringLength = oldMaxLength;
-          done();
+          api.clear(bp, function(err) {
+            assert.ifError(err);
+            done();
+          });
         });
         process.nextTick(function() {code.getterObject();});
       });
@@ -837,9 +871,11 @@ describe('v8debugapi', function() {
           assert((aVal as any).members[1].name.match(
             'Only first.*config.capture.maxProperties=1'));
 
-          api.clear(bp);
           config.capture.maxProperties = oldMax;
-          done();
+          api.clear(bp, function(err) {
+            assert.ifError(err);
+            done();
+          });
         });
         process.nextTick(function() {code.foo(2);});
       });
@@ -870,9 +906,11 @@ describe('v8debugapi', function() {
           assert((bVal as any).members[1].name.match(
             'Only first.*config.capture.maxProperties=1'));
 
-          api.clear(bp);
           config.capture.maxProperties = oldMax;
-          done();
+          api.clear(bp, function(err) {
+            assert.ifError(err);
+            done();
+          });
         });
         process.nextTick(function() {code.foo(2);});
       });
@@ -909,10 +947,12 @@ describe('v8debugapi', function() {
           // resulting in stringItems.length being 0.
           assert(stringItems.length === 1);
 
-          api.clear(bp);
           config.capture.maxDataSize = oldMaxData;
           config.capture.maxStringLength = oldMaxLength;
-          done();
+          api.clear(bp, function(err) {
+            assert.ifError(err);
+            done();
+          });
         });
         process.nextTick(function() {code.getterObject();});
       });
@@ -946,10 +986,12 @@ describe('v8debugapi', function() {
             assert.equal(((fooVal as any).members as any).length, 4);
             assert.strictEqual((foo as any).status, undefined);
 
-            api.clear(bp);
             config.capture.maxDataSize = oldMaxData;
             config.capture.maxProperties = oldMaxProps;
-            done();
+            api.clear(bp, function(err) {
+              assert.ifError(err);
+              done();
+            });
           });
           process.nextTick(function() {code.foo(2);});
         });
@@ -982,10 +1024,12 @@ describe('v8debugapi', function() {
             assert.equal(((fooVal as any).members as any).length, 3);
             assert.strictEqual((foo as any).status, undefined);
 
-            api.clear(bp);
             config.capture.maxDataSize = oldMaxData;
             config.capture.maxProperties = oldMaxProps;
-            done();
+            api.clear(bp, function(err) {
+              assert.ifError(err);
+              done();
+            });
           });
           process.nextTick(function() {code.foo(2);});
         });
@@ -1019,10 +1063,12 @@ describe('v8debugapi', function() {
               'Max data size reached'));
             assert(((fooVal as any).status as any).isError);
 
-            api.clear(bp);
             config.capture.maxDataSize = oldMaxData;
             config.capture.maxProperties = oldMaxProps;
-            done();
+            api.clear(bp, function(err) {
+              assert.ifError(err);
+              done();
+            });
           });
           process.nextTick(function() {code.foo(2);});
         });
@@ -1056,10 +1102,12 @@ describe('v8debugapi', function() {
               'Max data size reached'));
             assert(((fooVal as any).status as any).isError);
 
-            api.clear(bp);
             config.capture.maxDataSize = oldMaxData;
             config.capture.maxProperties = oldMaxProps;
-            done();
+            api.clear(bp, function(err) {
+              assert.ifError(err);
+              done();
+            });
           });
           process.nextTick(function() {code.foo(2);});
         });
@@ -1097,10 +1145,12 @@ describe('v8debugapi', function() {
               'Max data size reached'));
             assert((bArray.status as any).isError);
 
-            api.clear(bp);
             config.capture.maxDataSize = oldMaxData;
             config.capture.maxProperties = oldMaxProps;
-            done();
+            api.clear(bp, function(err) {
+              assert.ifError(err);
+              done();
+            });
           });
           process.nextTick(function() {code.foo(2);});
         });
@@ -1128,8 +1178,10 @@ describe('v8debugapi', function() {
             assert((expr as any).status && (expr as any).status.isError);
           }
 
-          api.clear(bp);
-          done();
+          api.clear(bp, function(err) {
+            assert.ifError(err);
+            done();
+          });
         });
         process.nextTick(function() {code.foo(3);});
       });
@@ -1153,8 +1205,10 @@ describe('v8debugapi', function() {
           const topFrame = bp.stackFrames[0];
           assert.equal(topFrame.locals[0].name, 'n');
           assert.equal(topFrame.locals[0].value, '5');
-          api.clear(bp);
-          done();
+          api.clear(bp, function(err) {
+            assert.ifError(err);
+            done();
+          });
         });
         process.nextTick(function() {code.foo(4); code.foo(5);});
       });
@@ -1182,8 +1236,10 @@ describe('v8debugapi', function() {
             assert.equal(topFrame['function'], 'foo');
             assert.equal(topFrame.locals[0].name, 'n');
             assert.equal(topFrame.locals[0].value, '3');
-            api.clear(bp);
-            done();
+            api.clear(bp, function(err) {
+              assert.ifError(err);
+              done();
+            });
           });
           process.nextTick(function() {tt.foo(2); tt.foo(3);});
         });
@@ -1227,8 +1283,10 @@ describe('v8debugapi', function() {
             assert.equal(topFrame.locals[0].name, 'j');
             assert.equal(topFrame.locals[0].value, '2');
             assert.equal(topFrame['function'], 'foo');
-            api.clear(bp);
-            done();
+            api.clear(bp, function(err) {
+              assert.ifError(err);
+              done();
+            });
           });
           process.nextTick(function() {tt.foo(1); tt.foo(2);});
         });
@@ -1259,8 +1317,10 @@ describe('v8debugapi', function() {
               assert((expr as any).value === String(Math.PI * 3));
             }
 
-            api.clear(bp);
-            done();
+            api.clear(bp, function(err) {
+              assert.ifError(err);
+              done();
+            });
           });
           process.nextTick(function() {tt.foo(3);});
         });
@@ -1301,8 +1361,10 @@ describe('v8debugapi', function() {
               }
             }
 
-            api.clear(bp);
-            done();
+            api.clear(bp, function(err) {
+              assert.ifError(err);
+              done();
+            });
           });
           process.nextTick(function() {tt.foo(3);});
         });
@@ -1324,9 +1386,11 @@ describe('v8debugapi', function() {
           process.nextTick(function() {
             code.foo(6);
             process.nextTick(function() {
-              api.clear(bp);
-              assert(stateIsClean(api));
-              done();
+              api.clear(bp, function(err) {
+                assert.ifError(err);
+                assert(stateIsClean(api));
+                done();
+              });
             });
           });
         });
@@ -1343,11 +1407,15 @@ describe('v8debugapi', function() {
           api.set(bp2, function(err) {
             assert.ifError(err);
             assert.equal(api.numBreakpoints_(), 2);
-            api.clear(bp1);
-            assert.equal(api.numBreakpoints_(), 1);
-            api.clear(bp2);
-            assert.equal(api.numBreakpoints_(), 0);
-            done();
+            api.clear(bp1, function(err) {
+              assert.ifError(err);
+              assert.equal(api.numBreakpoints_(), 1);
+              api.clear(bp2, function(err) {
+                assert.ifError(err);
+                assert.equal(api.numBreakpoints_(), 0);
+                done();
+              });
+            });
           });
         });
       });
@@ -1367,8 +1435,10 @@ describe('v8debugapi', function() {
           assert.ifError(err);
           assert.ok(bp.stackFrames);
 
-          api.clear(bp);
-          done();
+          api.clear(bp, function(err) {
+            assert.ifError(err);
+            done();
+          });
         });
         process.nextTick(function() {foo();});
       });
@@ -1396,8 +1466,11 @@ describe('v8debugapi', function() {
         assert.ifError(err);
         // TODO: Determine if the err parameter should be used.
         api.wait(bp, function(_err) {
-          api.clear(bp);
-          throw new Error(message);
+          api.clear(bp, function(err) {
+            assert.ifError(err);
+            throw new Error(message);
+          });
+
         });
         process.nextTick(function() {code.foo(1);});
       });
@@ -1422,8 +1495,10 @@ describe('v8debugapi', function() {
           const topFrame = bp.stackFrames[0];
           assert.ok(topFrame.locals.some((local) => (local.name === '_a')));
           assert.ok(topFrame.locals.some((local) => (local.name === 'res')));
-          api.clear(bp);
-          done();
+          api.clear(bp, function(err) {
+            assert.ifError(err);
+            done();
+          });
         });
       });
       process.nextTick(run);


### PR DESCRIPTION
This PR aims to change the exisiting v8debug API clear function to async
in order to prepare for the migration debug api from v8 to inspector,
as inspector api is async.