### PR TITLE
Remove args in state.ts#resolveLocalList

### DIFF
--- a/src/agent/state.ts
+++ b/src/agent/state.ts
@@ -325,8 +325,7 @@ class StateResolver {
       // We will use the values aggregated from the ScopeMirror traversal stored
       // in locals which will include any applicable arguments from the
       // invocation.
-      args = [];
-      locals = this.resolveLocalsList_(frame, args);
+      locals = this.resolveLocalsList_(frame);
       if (isEmpty(locals)) {
         locals = [];
       }
@@ -370,11 +369,7 @@ class StateResolver {
    * @returns {Array<Object>} - returns an array containing data about selected
    *  variables
    */
-  resolveLocalsList_(frame: v8Types.FrameMirror, args: any):
-      v8Types.ScopeMirror[] {
-    // TODO: Determine why `args` is never used in this function
-    args = args;
-
+  resolveLocalsList_(frame: v8Types.FrameMirror): v8Types.ScopeMirror[] {
     const self = this;
     const usedNames: {[name: string]: boolean} = {};
     const makeMirror = this.ctx_.MakeMirror;


### PR DESCRIPTION
Though cloud debugger has args in the proto, args is used to identify
passing variables to the functions. Locals, on the other hand is the
local variables defined within the function. However, stackdriver
debugger UI displays them in the same place with the order of passing
variables prior to local variables. In our case, debugger's call frame
will have the same effects of ordering passing variables prior to local
variables. We can sufficiently merge args and locals in one place.
That's the reason of removing args in the code.