### PR TITLE
fix: update dep gcp-metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "async": "^2.1.2",
     "coffee-script": "^1.9.3",
     "findit2": "^2.2.3",
-    "gcp-metadata": "^0.2.0",
+    "gcp-metadata": "^0.3.1",
     "lodash": "^4.12.0",
     "semver": "^5.1.0",
     "source-map": "^0.5.1",


### PR DESCRIPTION
The latest version of gcp-metadata provides an error upon a 404 reply from metadata service. Previously we were leaking the 404 html as the service context.

~~Partially~~ addresses https://stackoverflow.com/questions/46411341/stackdriver-debugger-on-google-compute-engine.

This bug also meant that we would incorrectly identify App Engine apps as GKE.