### PR TITLE
Remove powerscript in appveyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ install:
 # Post-install test scripts.
 test_script:
   # run tests
-  - ps: npm run build ; node_modules/.bin/mocha build/test --timeout 4000 --R
+  - npm run build ; node_modules/.bin/mocha build/test --timeout 4000 --R
 
 # Don't actually build using MSBuild
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ install:
 # Post-install test scripts.
 test_script:
   # run tests
-  - npm run build ; node_modules/.bin/mocha build/test --timeout 4000 --R
+  - ps: npm run build ; node_modules/.bin/mocha build/test --timeout 4000 --R
 
 # Don't actually build using MSBuild
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,8 @@ install:
 # Post-install test scripts.
 test_script:
   # run tests
-  - ps: npm run build ; node_modules/.bin/mocha build/test --timeout 4000 --R
+  - npm run build
+  - node_modules/.bin/mocha build/test --timeout 4000 --R
 
 # Don't actually build using MSBuild
 build: off

--- a/package-lock.json
+++ b/package-lock.json
@@ -1359,12 +1359,23 @@
       }
     },
     "gcp-metadata": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.2.0.tgz",
-      "integrity": "sha1-Ytr8pl86YxvIzi7Dt3Zh9fk4ego=",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.3.1.tgz",
+      "integrity": "sha512-5kJPX/RXuqoLmHiOOgkSDk/LI0QaXpEvZ3pvQP4ifjGGDKZKVSOjL/GcDjXA5kLxppFCOjmmsu0Uoop9d1upaQ==",
       "requires": {
         "extend": "3.0.1",
-        "retry-request": "2.0.5"
+        "retry-request": "3.0.0"
+      },
+      "dependencies": {
+        "retry-request": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.0.0.tgz",
+          "integrity": "sha1-i60rHc8Ek4uyEeLO2GLlkbgvGRc=",
+          "requires": {
+            "request": "2.81.0",
+            "through2": "2.0.3"
+          }
+        }
       }
     },
     "generate-function": {
@@ -1737,7 +1748,6 @@
       "integrity": "sha1-yCYERJEt2M7szYOHYdVvRik3vQI=",
       "requires": {
         "async": "2.5.0",
-        "gcp-metadata": "0.2.0",
         "google-auth-library": "0.10.0",
         "request": "2.81.0"
       }


### PR DESCRIPTION
As 32bit platform node will emitWarning, which will be send error to stderr. Appveyor powershell (ps) will fail for all stderr warnings. We use regular command line to execute tests instead.