### PR TITLE
Skip 32bit platform warning test after node 8.9.0

### DIFF
--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -345,7 +345,8 @@ describe('Debuglet', function() {
         // TODO: Handle the case where debuglet.debuggee is undefined
         assert.equal((debuglet.debuggee_ as Debuggee).project, projectId);
         const arch = process.arch;
-        if (semver.satisfies(process.version, '>=8.5') &&
+        if (semver.satisfies(process.version, '>=8.5.0') &&
+            semver.satisfies(process.version, '<8.9.0') &&
             (arch === 'ia32' || arch === 'x86') &&
             process.env.GCLOUD_USE_INSPECTOR) {
           assert(logText.includes(utils.messages.ASYNC_TRACES_WARNING));


### PR DESCRIPTION
As asnyc stack traces will not be turned on by default after node 8.9.0,
The warning message of 'async stack trace is not available on 32 bit
platform' no longer emitted. We will not emit this message after node
8.9.0.