### PR TITLE
feat: Enable isReady for debugger for GCF

### DIFF
--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -135,6 +135,14 @@ export class CachedPromise {
     }
   }
 }
+
+/**
+ * IsReady will return a promise to user after user starting the debug agent.
+ * This promise will be resolved when
+ * 1. Time since last listBreakpoint was within a heuristic time.
+ * 2. listBreakpoint completed successfully.
+ * 3. Debuggee expired or failed, listBreakpoint cannot be completed.
+ */
 export interface IsReady {
   isReady(): Promise<void>;
 }

--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -142,11 +142,14 @@ export class CachedPromise {
     this.promise = null;
   }
 }
+export interface IsReady {
+  isReady(): Promise<void>;
+}
 
 /**
  * IsReadyManager is a wrapper class to call debuglet.isReady().
  */
-export class IsReadyManager {
+class IsReadyImpl implements IsReady {
   private debuglet: Debuglet;
   constructor(debuglet: Debuglet) {
     this.debuglet = debuglet;
@@ -175,7 +178,7 @@ export class Debuglet extends EventEmitter {
   // registration was successful.
   private debuggeeRegistered: CachedPromise;
 
-  isReadyManager: IsReadyManager = new IsReadyManager(this);
+  isReadyManager: IsReady = new IsReadyImpl(this);
 
   // Exposed for testing
   config: DebugAgentConfig;

--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -141,7 +141,19 @@ export class CachedPromise {
   clear(): void {
     this.promise = null;
   }
+}
 
+/**
+ * IsReadyManager is a wrapper class to call debuglet.isReady().
+ */
+export class IsReadyManager {
+  private debuglet: Debuglet;
+  constructor(debuglet: Debuglet) {
+    this.debuglet = debuglet;
+  }
+  isReady(): Promise<void> {
+    return this.debuglet.isReady();
+  }
 }
 
 export class Debuglet extends EventEmitter {
@@ -162,6 +174,8 @@ export class Debuglet extends EventEmitter {
   // debuggeeRegistered is a CachedPromise only to be resolved after debuggee
   // registration was successful.
   private debuggeeRegistered: CachedPromise;
+
+  isReadyManager: IsReadyManager = new IsReadyManager(this);
 
   // Exposed for testing
   config: DebugAgentConfig;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 import {DebugAgentConfig, StackdriverConfig} from './agent/config';
-import {Debuglet} from './agent/debuglet';
+import {Debuglet, IsReadyManager} from './agent/debuglet';
 import {Debug} from './client/stackdriver/debug';
 
 const pjson = require('../../package.json');
@@ -36,7 +36,7 @@ let debuglet: Debuglet;
  * debug.startAgent();
  */
 export function start(options: DebugAgentConfig|StackdriverConfig): Debuglet|
-    undefined {
+    IsReadyManager {
   options = options || {};
   const agentConfig: DebugAgentConfig =
       (options as StackdriverConfig).debug || (options as DebugAgentConfig);
@@ -50,5 +50,5 @@ export function start(options: DebugAgentConfig|StackdriverConfig): Debuglet|
   debuglet = new Debuglet(debug, agentConfig);
   debuglet.start();
 
-  return debuglet;
+  return agentConfig.testMode_ ? debuglet : debuglet.isReadyManager;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,5 @@ export function start(options: DebugAgentConfig|StackdriverConfig): Debuglet|
   debuglet = new Debuglet(debug, agentConfig);
   debuglet.start();
 
-  // We return the debuglet to facilitate testing.
-  return agentConfig.testMode_ ? debuglet : undefined;
+  return debuglet;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 import {DebugAgentConfig, StackdriverConfig} from './agent/config';
-import {Debuglet, IsReadyManager} from './agent/debuglet';
+import {Debuglet, IsReady} from './agent/debuglet';
 import {Debug} from './client/stackdriver/debug';
 
 const pjson = require('../../package.json');
@@ -36,7 +36,7 @@ let debuglet: Debuglet;
  * debug.startAgent();
  */
 export function start(options: DebugAgentConfig|StackdriverConfig): Debuglet|
-    IsReadyManager {
+    IsReady {
   options = options || {};
   const agentConfig: DebugAgentConfig =
       (options as StackdriverConfig).debug || (options as DebugAgentConfig);

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -1012,14 +1012,12 @@ describe('Debuglet', function() {
                             .post(REGISTER_PATH)
                             .reply(200, {debuggee: {id: DEBUGGEE_ID}})
                             .get(BPS_PATH + '?successOnTimeout=true')
-                            .reply(404);
+                            .reply(404); // signal re-registration.
           const debugPromise = debuglet.isReadyManager.isReady();
-          debuglet.once('registered', function() {
-            debugPromise.then(() => {
-              debuglet.stop();
-              scope.done();
-              done();
-            });
+          debugPromise.then(() => {
+            debuglet.stop();
+            scope.done();
+            done();
           });
 
           debuglet.start();

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -1007,7 +1007,7 @@ describe('Debuglet', function() {
                           .get(BPS_PATH + '?successOnTimeout=true')
                           .twice()
                           .reply(200, {breakpoints: [breakpoint]});
-        const debugPromise = debuglet.isReady();
+        const debugPromise = debuglet.isReadyManager.isReady();
         debuglet.once('registered', function reg(id: string) {
           debugPromise.then(() => {
             // Once debugPromise is resolved, debuggee must be registered.
@@ -1037,7 +1037,7 @@ describe('Debuglet', function() {
                             .reply(200, {debuggee: {id: DEBUGGEE_ID}})
                             .get(BPS_PATH + '?successOnTimeout=true')
                             .reply(404);
-          const debugPromise = debuglet.isReady();
+          const debugPromise = debuglet.isReadyManager.isReady();
           debuglet.once('registered', function() {
             debugPromise.then(() => {
               debuglet.stop();

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -78,37 +78,13 @@ function verifyBreakpointRejection(re: RegExp, body: {breakpoint: any}) {
 }
 
 describe('CachedPromise', function() {
-  it('CachedPromise.get() is initially null', (done) => {
-    let cachedPromise = new CachedPromise();
-    assert(cachedPromise.get() === null);
-    done();
-  });
-
-  it('CachedPromise.get() is not null after refresh', (done) => {
-    let cachedPromise = new CachedPromise();
-    cachedPromise.refresh();
-    assert(cachedPromise.get() !== null)
-    done();
-  });
-
-  it('CachedPromise.get() will return a promise resolved after CachedPromise.resolve() is called', (done) => {
+  it('CachedPromise.get() will resolve after CachedPromise.resolve()', (done) => {
     this.timeout(2000);
     let cachedPromise = new CachedPromise();
-    cachedPromise.refresh();
-    (cachedPromise.get() as Promise<void>).then(() => {
+    cachedPromise.get().then(() => {
       done();
     });
     cachedPromise.resolve();
-  });
-  it('CachedPromise.get() will be null if it has been cleared', (done) => {
-    this.timeout(2000);
-    let cachedPromise = new CachedPromise();
-    assert.strictEqual(cachedPromise.get(), null);
-    cachedPromise.refresh();
-    assert(cachedPromise.get() !== null);
-    cachedPromise.clear();
-    assert.strictEqual(cachedPromise.get(), null);
-    done();
   });
 });
 


### PR DESCRIPTION
This PR mainly serve for GCF. The introduced isReady will return a
promise, and to be resolved either
1) time since last breakpoint fetch is within a heuristic duration.
2) breakpoint update completed.