### PR TITLE
 fix: only look for relevant files in scanner test

### DIFF
--- a/system-test/test-install.ts
+++ b/system-test/test-install.ts
@@ -56,7 +56,8 @@ debug.start({
     version: 'Some version'
   }
 });`,
-    description: 'imports the module and starts with a complete `serviceContext`'
+    description:
+        'imports the module and starts with a complete `serviceContext`'
   },
   {
     code: `import * as debug from '@google-cloud/debug-agent';

--- a/test/test-scanner.ts
+++ b/test/test-scanner.ts
@@ -25,6 +25,8 @@ const fixture = (file: string): string => {
 
 import * as scanner from '../src/agent/io/scanner';
 
+const COFFEE_FILES_REGEX = /^(.*\.js\.map)|(.*\.js)|(.*\.coffee)$/;
+
 describe('scanner', () => {
 
   describe('scan', () => {
@@ -44,7 +46,7 @@ describe('scanner', () => {
     });
 
     it('should be able to return all file stats directly', (done) => {
-      scanner.scan(true, fixture('coffee'), /.*$/).then((fileStats) => {
+      scanner.scan(true, fixture('coffee'), COFFEE_FILES_REGEX).then((fileStats) => {
         const files = Object.keys(fileStats.all());
         assert.strictEqual(files.length, 3);
         done();
@@ -52,7 +54,7 @@ describe('scanner', () => {
     });
 
     it('should be able to filter to return all file stats', (done) => {
-      scanner.scan(true, fixture('coffee'), /.*$/).then((fileStats) => {
+      scanner.scan(true, fixture('coffee'), COFFEE_FILES_REGEX).then((fileStats) => {
         const files = fileStats.selectFiles(/.*$/, '');
         assert.strictEqual(files.length, 3);
         done();

--- a/test/test-scanner.ts
+++ b/test/test-scanner.ts
@@ -46,19 +46,21 @@ describe('scanner', () => {
     });
 
     it('should be able to return all file stats directly', (done) => {
-      scanner.scan(true, fixture('coffee'), COFFEE_FILES_REGEX).then((fileStats) => {
-        const files = Object.keys(fileStats.all());
-        assert.strictEqual(files.length, 3);
-        done();
-      });
+      scanner.scan(true, fixture('coffee'), COFFEE_FILES_REGEX)
+          .then((fileStats) => {
+            const files = Object.keys(fileStats.all());
+            assert.strictEqual(files.length, 3);
+            done();
+          });
     });
 
     it('should be able to filter to return all file stats', (done) => {
-      scanner.scan(true, fixture('coffee'), COFFEE_FILES_REGEX).then((fileStats) => {
-        const files = fileStats.selectFiles(/.*$/, '');
-        assert.strictEqual(files.length, 3);
-        done();
-      });
+      scanner.scan(true, fixture('coffee'), COFFEE_FILES_REGEX)
+          .then((fileStats) => {
+            const files = fileStats.selectFiles(/.*$/, '');
+            assert.strictEqual(files.length, 3);
+            done();
+          });
     });
 
     it('should be able to filter filenames', (done) => {


### PR DESCRIPTION
The `scanner` tests would scan all files in the `coffee` fixtures
directory to make sure the `all` and `selectFiles` methods work
correctly.  However, the initial scan would incorrectly capture
`.DS_Store` files if they were present in the `coffee` directory.