### PR TITLE
 fix: `process` event listeners are removed on stop

### DIFF
--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -244,11 +244,12 @@ export class Debuglet extends EventEmitter {
     this.breakpointFetchedTimestamp = -Infinity;
     this.debuggeeRegistered = new CachedPromise();
 
-    const debugAgentWarningListener = (warning: NodeJS.ErrnoException) => {
+    const that = this;
+    function debugAgentWarningListener(warning: NodeJS.ErrnoException) {
       if (warning.code === 'INSPECTOR_ASYNC_STACK_TRACES_NOT_AVAILABLE') {
-        this.logger.info(utils.messages.ASYNC_TRACES_WARNING);
+        that.logger.info(utils.messages.ASYNC_TRACES_WARNING);
       }
-    };
+    }
 
     this.warningListener = debugAgentWarningListener;
   }

--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -244,12 +244,11 @@ export class Debuglet extends EventEmitter {
     this.breakpointFetchedTimestamp = -Infinity;
     this.debuggeeRegistered = new CachedPromise();
 
-    const that = this;
-    function debugAgentWarningListener(warning: NodeJS.ErrnoException) {
+    const debugAgentWarningListener = (warning: NodeJS.ErrnoException) => {
       if (warning.code === 'INSPECTOR_ASYNC_STACK_TRACES_NOT_AVAILABLE') {
-        that.logger.info(utils.messages.ASYNC_TRACES_WARNING);
+        this.logger.info(utils.messages.ASYNC_TRACES_WARNING);
       }
-    }
+    };
 
     this.warningListener = debugAgentWarningListener;
   }

--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -164,7 +164,9 @@ export class Debuglet extends EventEmitter {
   private project: string|null;
   private controller: Controller;
   private completedBreakpointMap: {[key: string]: boolean};
-  private warningListener: ((warning: NodeJS.ErrnoException) => void) & { fromGcpDebugAgent: boolean; };
+  private warningListener: ((warning: NodeJS.ErrnoException) => void)&{
+    fromGcpDebugAgent: boolean;
+  };
 
   // breakpointFetchedTimestamp represents the last timestamp when
   // breakpointFetched was resolved, which means breakpoint update was
@@ -244,14 +246,11 @@ export class Debuglet extends EventEmitter {
     this.breakpointFetchedTimestamp = -Infinity;
     this.debuggeeRegistered = new CachedPromise();
 
-    this.warningListener = Object.assign(
-      (warning: NodeJS.ErrnoException) => {
-        if (warning.code === 'INSPECTOR_ASYNC_STACK_TRACES_NOT_AVAILABLE') {
-          this.logger.info(utils.messages.ASYNC_TRACES_WARNING);
-        }
-      },
-      { fromGcpDebugAgent: true }
-    );
+    this.warningListener = Object.assign((warning: NodeJS.ErrnoException) => {
+      if (warning.code === 'INSPECTOR_ASYNC_STACK_TRACES_NOT_AVAILABLE') {
+        this.logger.info(utils.messages.ASYNC_TRACES_WARNING);
+      }
+    }, {fromGcpDebugAgent: true});
   }
 
   static normalizeConfig_(config: DebugAgentConfig): ResolvedDebugAgentConfig {

--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -164,9 +164,7 @@ export class Debuglet extends EventEmitter {
   private project: string|null;
   private controller: Controller;
   private completedBreakpointMap: {[key: string]: boolean};
-  private warningListener: ((warning: NodeJS.ErrnoException) => void)&{
-    fromGcpDebugAgent: boolean;
-  };
+  private warningListener: (warning: NodeJS.ErrnoException) => void;
 
   // breakpointFetchedTimestamp represents the last timestamp when
   // breakpointFetched was resolved, which means breakpoint update was
@@ -246,11 +244,14 @@ export class Debuglet extends EventEmitter {
     this.breakpointFetchedTimestamp = -Infinity;
     this.debuggeeRegistered = new CachedPromise();
 
-    this.warningListener = Object.assign((warning: NodeJS.ErrnoException) => {
+    const that = this;
+    function debugAgentWarningListener(warning: NodeJS.ErrnoException) {
       if (warning.code === 'INSPECTOR_ASYNC_STACK_TRACES_NOT_AVAILABLE') {
-        this.logger.info(utils.messages.ASYNC_TRACES_WARNING);
+        that.logger.info(utils.messages.ASYNC_TRACES_WARNING);
       }
-    }, {fromGcpDebugAgent: true});
+    }
+
+    this.warningListener = debugAgentWarningListener;
   }
 
   static normalizeConfig_(config: DebugAgentConfig): ResolvedDebugAgentConfig {

--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -164,6 +164,7 @@ export class Debuglet extends EventEmitter {
   private project: string|null;
   private controller: Controller;
   private completedBreakpointMap: {[key: string]: boolean};
+  private warningListener: ((warning: NodeJS.ErrnoException) => void) & { fromGcpDebugAgent: boolean; };
 
   // breakpointFetchedTimestamp represents the last timestamp when
   // breakpointFetched was resolved, which means breakpoint update was
@@ -242,6 +243,15 @@ export class Debuglet extends EventEmitter {
     this.breakpointFetched = null;
     this.breakpointFetchedTimestamp = -Infinity;
     this.debuggeeRegistered = new CachedPromise();
+
+    this.warningListener = Object.assign(
+      (warning: NodeJS.ErrnoException) => {
+        if (warning.code === 'INSPECTOR_ASYNC_STACK_TRACES_NOT_AVAILABLE') {
+          this.logger.info(utils.messages.ASYNC_TRACES_WARNING);
+        }
+      },
+      { fromGcpDebugAgent: true }
+    );
   }
 
   static normalizeConfig_(config: DebugAgentConfig): ResolvedDebugAgentConfig {
@@ -274,11 +284,7 @@ export class Debuglet extends EventEmitter {
    */
   async start(): Promise<void> {
     const that = this;
-    process.on('warning', (warning: NodeJS.ErrnoException) => {
-      if (warning.code === 'INSPECTOR_ASYNC_STACK_TRACES_NOT_AVAILABLE') {
-        that.logger.info(utils.messages.ASYNC_TRACES_WARNING);
-      }
-    });
+    process.on('warning', this.warningListener);
 
     const stat = promisify(fs.stat);
 
@@ -940,6 +946,7 @@ export class Debuglet extends EventEmitter {
     assert.ok(this.running, 'stop can only be called on a running agent');
     this.logger.debug('Stopping Debuglet');
     this.running = false;
+    process.removeListener('warning', this.warningListener);
     this.emit('stopped');
   }
 

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -351,14 +351,12 @@ describe('Debuglet', () => {
       assert.deepEqual(mergedConfig, compareConfig);
     });
 
-    it.only(
+    it(
         'should remove inspector warning listener on debug.stop', (done) => {
           function countCustomListeners(): number {
             let count = 0;
             for (const fn of process.listeners('warning')) {
-              if ((fn as {} as {
-                    fromGcpDebugAgent: boolean
-                  }).fromGcpDebugAgent) {
+              if (fn.name === 'debugAgentWarningListener') {
                 count++;
               }
             }

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -351,33 +351,32 @@ describe('Debuglet', () => {
       assert.deepEqual(mergedConfig, compareConfig);
     });
 
-    it(
-        'should remove inspector warning listener on debug.stop', (done) => {
-          function countCustomListeners(): number {
-            let count = 0;
-            for (const fn of process.listeners('warning')) {
-              if (fn.name === 'debugAgentWarningListener') {
-                count++;
-              }
-            }
-            return count;
+    it('should remove inspector warning listener on debug.stop', (done) => {
+      function countCustomListeners(): number {
+        let count = 0;
+        for (const fn of process.listeners('warning')) {
+          if (fn.name === 'debugAgentWarningListener') {
+            count++;
           }
+        }
+        return count;
+      }
 
-          const projectId = '11020304f2934-a';
-          const debug =
-              new Debug({projectId, credentials: fakeCredentials}, packageInfo);
-          const debuglet = new Debuglet(debug, defaultConfig);
-          debuglet.once('started', () => {
-            assert.strictEqual(countCustomListeners(), 1);
-            debuglet.stop();
-          });
-          debuglet.once('stopped', () => {
-            assert.strictEqual(countCustomListeners(), 0);
-            done();
-          });
-          assert.strictEqual(countCustomListeners(), 0);
-          debuglet.start();
-        });
+      const projectId = '11020304f2934-a';
+      const debug =
+          new Debug({projectId, credentials: fakeCredentials}, packageInfo);
+      const debuglet = new Debuglet(debug, defaultConfig);
+      debuglet.once('started', () => {
+        assert.strictEqual(countCustomListeners(), 1);
+        debuglet.stop();
+      });
+      debuglet.once('stopped', () => {
+        assert.strictEqual(countCustomListeners(), 0);
+        done();
+      });
+      assert.strictEqual(countCustomListeners(), 0);
+      debuglet.start();
+    });
 
     it('should elaborate on inspector warning on 32 bit but not on 64 bit',
        (done) => {

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -351,6 +351,33 @@ describe('Debuglet', () => {
       assert.deepEqual(mergedConfig, compareConfig);
     });
 
+    it.only('should remove inspector warning listener on debug.stop', (done) => {
+      function countCustomListeners(): number {
+        let count = 0;
+        for (const fn of process.listeners('warning')) {
+          if ((fn as {} as { fromGcpDebugAgent: boolean }).fromGcpDebugAgent) {
+            count++;
+          }
+        }
+        return count;
+      }
+
+      const projectId = '11020304f2934-a';
+      const debug =
+          new Debug({projectId, credentials: fakeCredentials}, packageInfo);
+      const debuglet = new Debuglet(debug, defaultConfig);
+      debuglet.once('started', () => {
+        assert.strictEqual(countCustomListeners(), 1);
+        debuglet.stop();
+      });
+      debuglet.once('stopped', () => {
+        assert.strictEqual(countCustomListeners(), 0);
+        done();
+      });
+      assert.strictEqual(countCustomListeners(), 0);
+      debuglet.start();
+    });
+
     it('should elaborate on inspector warning on 32 bit but not on 64 bit',
        (done) => {
          const projectId = '11020304f2934-a';

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -351,32 +351,35 @@ describe('Debuglet', () => {
       assert.deepEqual(mergedConfig, compareConfig);
     });
 
-    it.only('should remove inspector warning listener on debug.stop', (done) => {
-      function countCustomListeners(): number {
-        let count = 0;
-        for (const fn of process.listeners('warning')) {
-          if ((fn as {} as { fromGcpDebugAgent: boolean }).fromGcpDebugAgent) {
-            count++;
+    it.only(
+        'should remove inspector warning listener on debug.stop', (done) => {
+          function countCustomListeners(): number {
+            let count = 0;
+            for (const fn of process.listeners('warning')) {
+              if ((fn as {} as {
+                    fromGcpDebugAgent: boolean
+                  }).fromGcpDebugAgent) {
+                count++;
+              }
+            }
+            return count;
           }
-        }
-        return count;
-      }
 
-      const projectId = '11020304f2934-a';
-      const debug =
-          new Debug({projectId, credentials: fakeCredentials}, packageInfo);
-      const debuglet = new Debuglet(debug, defaultConfig);
-      debuglet.once('started', () => {
-        assert.strictEqual(countCustomListeners(), 1);
-        debuglet.stop();
-      });
-      debuglet.once('stopped', () => {
-        assert.strictEqual(countCustomListeners(), 0);
-        done();
-      });
-      assert.strictEqual(countCustomListeners(), 0);
-      debuglet.start();
-    });
+          const projectId = '11020304f2934-a';
+          const debug =
+              new Debug({projectId, credentials: fakeCredentials}, packageInfo);
+          const debuglet = new Debuglet(debug, defaultConfig);
+          debuglet.once('started', () => {
+            assert.strictEqual(countCustomListeners(), 1);
+            debuglet.stop();
+          });
+          debuglet.once('stopped', () => {
+            assert.strictEqual(countCustomListeners(), 0);
+            done();
+          });
+          assert.strictEqual(countCustomListeners(), 0);
+          debuglet.start();
+        });
 
     it('should elaborate on inspector warning on 32 bit but not on 64 bit',
        (done) => {


### PR DESCRIPTION
When the agent is started, a `warning` event listener is added
to `process`.  With this change, the listener is removed when
the agent is stopped.