### PR TITLE
fix: Remove the `process` warning listener

### DIFF
--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -273,12 +273,6 @@ export class Debuglet extends EventEmitter {
    */
   async start(): Promise<void> {
     const that = this;
-    process.on('warning', (warning: NodeJS.ErrnoException) => {
-      if (warning.code === 'INSPECTOR_ASYNC_STACK_TRACES_NOT_AVAILABLE') {
-        that.logger.info(utils.messages.ASYNC_TRACES_WARNING);
-      }
-    });
-
     const stat = promisify(fs.stat);
 
     try {

--- a/src/agent/util/utils.ts
+++ b/src/agent/util/utils.ts
@@ -25,10 +25,6 @@ export const messages = {
   INVALID_LINE_NUMBER: 'Invalid snapshot position: ',
   COULD_NOT_FIND_OUTPUT_FILE:
       'Could not determine the output file associated with the transpiled input file',
-  ASYNC_TRACES_WARNING:
-      'The Stackdriver Debugger for Node.js does not require V8 Inspector ' +
-      'async stack traces. The INSPECTOR_ASYNC_STACK_TRACES_NOT_AVAILABLE ' +
-      'can be ignored.',
   INSPECTOR_NOT_AVAILABLE:
       'The V8 Inspector protocol is only available in Node 8+'
 };

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -351,42 +351,6 @@ describe('Debuglet', () => {
       assert.deepEqual(mergedConfig, compareConfig);
     });
 
-    it('should elaborate on inspector warning on 32 bit but not on 64 bit',
-       (done) => {
-         const projectId = '11020304f2934-a';
-         const debug =
-             new Debug({projectId, credentials: fakeCredentials}, packageInfo);
-         const debuglet = new Debuglet(debug, defaultConfig);
-         let logText = '';
-         debuglet.logger.info = (s: string) => {
-           logText += s;
-         };
-         nocks.projectId('project-via-metadata');
-         const scope = nock(API).post(REGISTER_PATH).reply(200, {
-           debuggee: {id: DEBUGGEE_ID}
-         });
-
-         debuglet.once('registered', (id: string) => {
-           assert.equal(id, DEBUGGEE_ID);
-           // TODO: Handle the case where debuglet.debuggee is undefined
-           assert.equal((debuglet.debuggee as Debuggee).project, projectId);
-           const arch = process.arch;
-           if (semver.satisfies(process.version, '>=8.5.0') &&
-               semver.satisfies(process.version, '<8.9.0') &&
-               (arch === 'ia32' || arch === 'x86') &&
-               process.env.GCLOUD_USE_INSPECTOR) {
-             assert(logText.includes(utils.messages.ASYNC_TRACES_WARNING));
-           } else {
-             assert(!logText.includes(utils.messages.ASYNC_TRACES_WARNING));
-           }
-           debuglet.stop();
-           scope.done();
-           done();
-         });
-
-         debuglet.start();
-       });
-
     it('should not start when projectId is not available', (done) => {
       const savedGetProjectId = Debuglet.getProjectId;
       Debuglet.getProjectId = () => {


### PR DESCRIPTION
Node 8.5.0 introduced a change where a warning message discussing
the use of async traces would be printed when using the debug
agent with the inspector protocol.  At that time, a listener was
added that listened to that warning and also printed a message
stating that the warning does not impact the debug agent.

At this point, the underlying issue causing the warning message to
appear has been fixed in Node, and, as such, the associated warning
listener in the debug agent has be removed.