### PR TITLE
chore: license check as posttest

### DIFF
--- a/js-green-licenses.json
+++ b/js-green-licenses.json
@@ -1,0 +1,6 @@
+{
+  "packageWhitelist": [
+    "log-driver",
+    "modelo"
+  ]
+}

--- a/js-green-licenses.json
+++ b/js-green-licenses.json
@@ -1,6 +1,5 @@
 {
   "packageWhitelist": [
-    "log-driver",
-    "modelo"
+    "log-driver"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -335,6 +335,16 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
+    "axios": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.2.6",
+        "is-buffer": "1.1.6"
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -454,6 +464,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "builtins": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
     },
     "camelcase": {
@@ -1129,6 +1145,26 @@
       "resolved": "https://registry.npmjs.org/findit2/-/findit2-2.2.3.tgz",
       "integrity": "sha1-WKRmaX34piBc39vzlVNri9d3pfY="
     },
+    "follow-redirects": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.6.tgz",
+      "integrity": "sha512-FrMqZ/FONtHnbqO651UPpfRUVukIEwJhXMfdr/JWAmrDbeYBu773b1J6gdWDyRIj4hvvzQEHoEOTrdR8o6KLYA==",
+      "dev": true,
+      "requires": {
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
@@ -1395,9 +1431,9 @@
       }
     },
     "gts": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/gts/-/gts-0.5.2.tgz",
-      "integrity": "sha512-XnsRWIBBAwXx+ta/ra0foqQ7D1nUqZ0GbL2I5vJK96wK14X16xl3uaMGb1D+DZDWfaQAH7h+R1F7KEuUfvDsNQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/gts/-/gts-0.5.3.tgz",
+      "integrity": "sha512-MiC5I1cAYjuGq68Xc9esn1qQcfl/on154+Oux8y6xWv03Ql9DGGsAokFVzgqNFDV65wd38uXYcPNaeeIl/EOjg==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
@@ -1913,6 +1949,49 @@
           "requires": {
             "has-flag": "1.0.0"
           }
+        }
+      }
+    },
+    "js-green-licenses": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/js-green-licenses/-/js-green-licenses-0.2.0.tgz",
+      "integrity": "sha512-AkUDqKfvOREpd+ZbZRIdP5YRbEyNsyxMBgvMrfjs4zk5TpYJondN+Xcvm57tj7e1cgYaoBg5yx9g99eXEoYuqA==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "axios": "0.17.1",
+        "npm-package-arg": "6.0.0",
+        "package-json": "4.0.1",
+        "pify": "3.0.0",
+        "spdx-correct": "2.0.4",
+        "spdx-satisfies": "0.1.3"
+      },
+      "dependencies": {
+        "spdx-correct": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-2.0.4.tgz",
+          "integrity": "sha512-c+4gPpt9YDhz7cHlz5UrsHzxxRi4ksclxnEEKsuGT9JdwSC+ZNmsGbYRzzgxyZaBYpcWnlu+4lPcdLKx4DOCmA==",
+          "dev": true,
+          "requires": {
+            "spdx-expression-parse": "2.0.2",
+            "spdx-license-ids": "2.0.1"
+          }
+        },
+        "spdx-expression-parse": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-2.0.2.tgz",
+          "integrity": "sha512-oFxOkWCfFS0ltNp0H66gXlU4NF6bxg7RkoTYR0413t+yTY9zyj+AIWsjtN8dcVp6703ijDYBWBIARlJ7DkyP9Q==",
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "2.0.0",
+            "spdx-license-ids": "2.0.1"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-2.0.1.tgz",
+          "integrity": "sha1-AgF7zDU07k/+9tWNIOfT6aHDyOw=",
+          "dev": true
         }
       }
     },
@@ -2450,6 +2529,18 @@
         "validate-npm-package-license": "3.0.1"
       }
     },
+    "npm-package-arg": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.0.0.tgz",
+      "integrity": "sha512-hwC7g81KLgRmchv9ol6f3Fx4Yyc9ARX5X5niDHVILgpuvf08JRIgOZcEfpFXli3BgESoTrkauqorXm6UbvSgSg==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "osenv": "0.1.4",
+        "semver": "5.4.1",
+        "validate-npm-package-name": "3.0.0"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -2533,11 +2624,27 @@
         "wordwrap": "1.0.0"
       }
     },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
+    },
+    "osenv": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "p-finally": {
       "version": "1.0.0",
@@ -2942,6 +3049,16 @@
         "source-map": "0.6.1"
       }
     },
+    "spdx-compare": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-0.1.2.tgz",
+      "integrity": "sha1-sGrz6jSvdDfZGp9Enq8tLpPDyPs=",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "1.0.4",
+        "spdx-ranges": "1.0.1"
+      }
+    },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
@@ -2950,6 +3067,12 @@
       "requires": {
         "spdx-license-ids": "1.2.2"
       }
+    },
+    "spdx-exceptions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.0.0.tgz",
+      "integrity": "sha1-aoDpnx8z5ArPSX9qQwz0mWnwE6g=",
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -2962,6 +3085,22 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
+    },
+    "spdx-ranges": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-1.0.1.tgz",
+      "integrity": "sha1-D07se46kjtIC43S7iULo0Y3AET4=",
+      "dev": true
+    },
+    "spdx-satisfies": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-0.1.3.tgz",
+      "integrity": "sha1-Z6HydOYRXUquKK/kdNt2FkvhC9w=",
+      "dev": true,
+      "requires": {
+        "spdx-compare": "0.1.2",
+        "spdx-expression-parse": "1.0.4"
+      }
     },
     "split": {
       "version": "1.0.1",
@@ -3405,6 +3544,15 @@
       "requires": {
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
+      }
+    },
+    "validate-npm-package-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+      "dev": true,
+      "requires": {
+        "builtins": "1.0.3"
       }
     },
     "verror": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "glob": "^7.1.2",
     "gts": "latest",
     "istanbul": "^0.4.1",
+    "js-green-licenses": "^0.2.0",
     "mkdirp": "^0.5.1",
     "mocha": "^4.0.1",
     "ncp": "^2.0.0",
@@ -88,8 +89,9 @@
     "compile-scripts": "tsc -p scripts-tsconfig.json",
     "fix": "gts fix",
     "pretest": "npm run compile",
-    "posttest": "npm run check",
-    "prepack": "npm run compile"
+    "posttest": "npm run check && npm run license-check",
+    "prepack": "npm run compile",
+    "license-check": "jsgl --local ."
   },
   "files": [
     "CHANGELOG.md",


### PR DESCRIPTION
There are two problematic dependencies: log-driver & modelo. They come
from googleapis/nodejs-common. I created an issue for that:
https://github.com/googleapis/nodejs-common/issues/16. Until it's
resolved, this repo must have a package whitelist.