### PR TITLE
feat: GAE_DEPLOYMENT_ID used for minor version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@google-cloud/common": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.15.1.tgz",
-      "integrity": "sha512-cnVtHLvyiSQvb1RzXWDp7PA1sA8Jmc47+wp/xwHwdGOlQZfKog5iluZ0C/LB8iklFXpcTwlNMorqLuZ/qH0DDA==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.16.1.tgz",
+      "integrity": "sha512-1sufDsSfgJ7fuBLq+ux8t3TlydMlyWl9kPZx2WdLINkGtf5RjvXX6EWYZiCMKe8flJ3oC0l95j5atN2uX5n3rg==",
       "requires": {
         "array-uniq": "1.0.3",
         "arrify": "1.0.1",
@@ -16,7 +16,7 @@
         "duplexify": "3.5.1",
         "ent": "2.2.0",
         "extend": "3.0.1",
-        "google-auto-auth": "0.8.1",
+        "google-auto-auth": "0.9.4",
         "is": "3.2.1",
         "log-driver": "1.2.5",
         "methmeth": "1.1.0",
@@ -27,6 +27,29 @@
         "stream-events": "1.0.2",
         "string-format-obj": "1.1.0",
         "through2": "2.0.3"
+      },
+      "dependencies": {
+        "gcp-metadata": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.6.1.tgz",
+          "integrity": "sha512-Ju3brkV7kYOBP5s3Z6HS2xd7gyH9MDfuKeB+y51SsI8GPrD37NOB5Re9fWXQQVAkd74zzVOScnNic1lcRsWD9w==",
+          "requires": {
+            "axios": "0.17.1",
+            "extend": "3.0.1",
+            "retry-axios": "0.3.0"
+          }
+        },
+        "google-auto-auth": {
+          "version": "0.9.4",
+          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.9.4.tgz",
+          "integrity": "sha512-a/gSNZ2RCaJxriBO/A010IHmdiQeoZS0EE83G7R/yV/OGXM9zd3otRqlcfRUomBLXf9XgsJ0h6bCp7bo+qaPvw==",
+          "requires": {
+            "async": "2.6.0",
+            "gcp-metadata": "0.6.1",
+            "google-auth-library": "0.12.0",
+            "request": "2.83.0"
+          }
+        }
       }
     },
     "@types/acorn": {
@@ -68,7 +91,7 @@
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.2"
+        "@types/node": "9.4.6"
       }
     },
     "@types/glob": {
@@ -79,7 +102,7 @@
       "requires": {
         "@types/events": "1.1.0",
         "@types/minimatch": "3.0.2",
-        "@types/node": "8.5.2"
+        "@types/node": "9.4.6"
       }
     },
     "@types/lodash": {
@@ -100,7 +123,7 @@
       "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.2"
+        "@types/node": "9.4.6"
       }
     },
     "@types/mocha": {
@@ -115,7 +138,7 @@
       "integrity": "sha512-TeiJ7uvv/92ugSqZ0v9l0eNXzutlki0aK+R1K5bfA5SYUil46ITlxLW4iNTCf55P4L5weCmaOdtxGeGWvudwPg==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.2"
+        "@types/node": "9.4.6"
       }
     },
     "@types/nock": {
@@ -124,13 +147,13 @@
       "integrity": "sha512-Ykk50z1MKpHDRmnBJb6kn3rU03cCsbjHmqCzY3eyeDNxdz3mrgbbwwXRXzBnPXkD9qzGh1ZU9XLdbQVp6i0+gQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.2"
+        "@types/node": "9.4.6"
       }
     },
     "@types/node": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.2.tgz",
-      "integrity": "sha512-KA4GKOpgXnrqEH2eCVhiv2CsxgXGQJgV1X0vsGlh+WCnxbeAE1GT44ZsTU1IN5dEeV/gDupKa7gWo08V5IxWVQ==",
+      "version": "9.4.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
+      "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
       "dev": true
     },
     "@types/once": {
@@ -158,7 +181,7 @@
       "dev": true,
       "requires": {
         "@types/form-data": "2.2.1",
-        "@types/node": "8.5.2"
+        "@types/node": "9.4.6"
       }
     },
     "@types/rimraf": {
@@ -168,7 +191,7 @@
       "dev": true,
       "requires": {
         "@types/glob": "5.0.34",
-        "@types/node": "8.5.2"
+        "@types/node": "9.4.6"
       }
     },
     "@types/semver": {
@@ -339,7 +362,6 @@
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
       "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
-      "dev": true,
       "requires": {
         "follow-redirects": "1.2.6",
         "is-buffer": "1.1.6"
@@ -1149,7 +1171,6 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.6.tgz",
       "integrity": "sha512-FrMqZ/FONtHnbqO651UPpfRUVukIEwJhXMfdr/JWAmrDbeYBu773b1J6gdWDyRIj4hvvzQEHoEOTrdR8o6KLYA==",
-      "dev": true,
       "requires": {
         "debug": "3.1.0"
       },
@@ -1158,7 +1179,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -1197,12 +1217,13 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "gcp-metadata": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.4.1.tgz",
-      "integrity": "sha512-yFE7v+NyoMiTOi2L6r8q87eVbiZCKooJNPKXTHhBStga8pwwgWofK9iHl00qd0XevZxcpk7ORaEL/ALuTvlaGQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.5.0.tgz",
+      "integrity": "sha512-G+haBuoUrnLzzJfnAuefG2yR0TC7Pgn8iw9L7YgacbBeQYx+/QiTulmYfetj923HMz0nWNW7Q7/fmNCLFMMN4Q==",
       "requires": {
+        "axios": "0.17.1",
         "extend": "3.0.1",
-        "retry-request": "3.3.1"
+        "retry-axios": "0.3.0"
       }
     },
     "get-stream": {
@@ -1358,28 +1379,6 @@
         "request": "2.83.0"
       }
     },
-    "google-auto-auth": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.8.1.tgz",
-      "integrity": "sha512-v5a4mHIkhvbtKNILxnOYgOw+cin/jfLR0pEj1ids2jn9p0OyxYUXjSJbCEciuAorQao9Y55w0zJIc8yW1rIPaA==",
-      "requires": {
-        "async": "2.6.0",
-        "gcp-metadata": "0.3.1",
-        "google-auth-library": "0.12.0",
-        "request": "2.83.0"
-      },
-      "dependencies": {
-        "gcp-metadata": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.3.1.tgz",
-          "integrity": "sha512-5kJPX/RXuqoLmHiOOgkSDk/LI0QaXpEvZ3pvQP4ifjGGDKZKVSOjL/GcDjXA5kLxppFCOjmmsu0Uoop9d1upaQ==",
-          "requires": {
-            "extend": "3.0.1",
-            "retry-request": "3.3.1"
-          }
-        }
-      }
-    },
     "google-p12-pem": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-0.1.2.tgz",
@@ -1436,7 +1435,7 @@
       "integrity": "sha512-MiC5I1cAYjuGq68Xc9esn1qQcfl/on154+Oux8y6xWv03Ql9DGGsAokFVzgqNFDV65wd38uXYcPNaeeIl/EOjg==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "clang-format": "1.2.1",
         "inquirer": "3.3.0",
         "meow": "4.0.0",
@@ -1457,23 +1456,29 @@
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
         },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -1755,8 +1760,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -1953,9 +1957,9 @@
       }
     },
     "js-green-licenses": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/js-green-licenses/-/js-green-licenses-0.2.0.tgz",
-      "integrity": "sha512-AkUDqKfvOREpd+ZbZRIdP5YRbEyNsyxMBgvMrfjs4zk5TpYJondN+Xcvm57tj7e1cgYaoBg5yx9g99eXEoYuqA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/js-green-licenses/-/js-green-licenses-0.4.0.tgz",
+      "integrity": "sha512-LpkL/9coWxNUmJ9/jxng3uvcLK6Qso2yaz7QBjO+atwtX/xmt8MrCtbkolYdhPZl/fq5dRs7Q7BLA8Ne3DKZ2w==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -1964,7 +1968,8 @@
         "package-json": "4.0.1",
         "pify": "3.0.0",
         "spdx-correct": "2.0.4",
-        "spdx-satisfies": "0.1.3"
+        "spdx-satisfies": "0.1.3",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
         "spdx-correct": {
@@ -2409,9 +2414,9 @@
       }
     },
     "mocha": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.1.tgz",
+      "integrity": "sha512-SpwyojlnE/WRBNGtvJSNfllfm5PqEDFxcWluSIgLeSBJtXG4DmoX2NNAeEA7rP5kK+79VgtVq8nG6HskaL1ykg==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -2471,8 +2476,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -2934,6 +2938,11 @@
         "onetime": "2.0.1",
         "signal-exit": "3.0.2"
       }
+    },
+    "retry-axios": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-0.3.0.tgz",
+      "integrity": "sha512-6vOCghodB5p5N/ZOqug7A3WsT42TULZ7NErUi4lP3KtwtXgz4hE/43LWHsFuHuBfXRmOm/tjXBWAjnObrcy+yg=="
     },
     "retry-request": {
       "version": "3.3.1",

--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -254,12 +254,8 @@ export class Debuglet extends EventEmitter {
       serviceContext: {
         service: process.env.GAE_SERVICE || process.env.GAE_MODULE_NAME,
         version: process.env.GAE_VERSION || process.env.GAE_MODULE_VERSION,
-        // Debug UI expects GAE_MINOR_VERSION to be available for AppEngine, but
-        // AppEngine Flex doesn't have this environment variable. We provide a
-        // fake value as a work-around, but only on Flex (GAE_SERVICE will be
-        // defined on Flex).
-        minorVersion_: process.env.GAE_MINOR_VERSION ||
-            (process.env.GAE_SERVICE ? 'fake-minor-version' : undefined)
+        minorVersion_:
+            process.env.GAE_DEPLOYMENT_ID || process.env.GAE_MINOR_VERSION
       }
     };
 
@@ -303,9 +299,9 @@ export class Debuglet extends EventEmitter {
     if (!that.config.allowRootAsWorkingDirectory &&
         path.join(workingDir, '..') === workingDir) {
       const message = 'The working directory is a root directory. Disabling ' +
-        'to avoid a scan of the entire filesystem for JavaScript files. ' +
-        'Use config \allowRootAsWorkingDirectory` if you really want to ' +
-        'do this.';
+          'to avoid a scan of the entire filesystem for JavaScript files. ' +
+          'Use config \allowRootAsWorkingDirectory` if you really want to ' +
+          'do this.';
       that.logger.error(message);
       that.emit('initError', new Error(message));
       return;
@@ -516,11 +512,11 @@ export class Debuglet extends EventEmitter {
     return metadata.isAvailable();
   }
 
-  static async getProjectIdFromMetadata() : Promise<string> {
+  static async getProjectIdFromMetadata(): Promise<string> {
     return (await metadata.project('project-id')).data as string;
   }
 
-  static async getClusterNameFromMetadata() : Promise<string> {
+  static async getClusterNameFromMetadata(): Promise<string> {
     return (await metadata.instance('attributes/cluster-name')).data as string;
   }
 

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -706,9 +706,9 @@ describe('Debuglet', () => {
 
          debuglet.on('initError', (err: Error) => {
            const errorMessage = 'The working directory is a root ' +
-             'directory. Disabling to avoid a scan of the entire filesystem ' +
-             'for JavaScript files. Use config \allowRootAsWorkingDirectory` ' +
-             'if you really want to do this.';
+               'directory. Disabling to avoid a scan of the entire filesystem ' +
+               'for JavaScript files. Use config \allowRootAsWorkingDirectory` ' +
+               'if you really want to do this.';
            assert.ok(err);
            assert.strictEqual(err.message, errorMessage);
            assert.ok(text.includes(errorMessage));


### PR DESCRIPTION
The `GAE_DEPLOYMENT_ID` environment variable (with a fallback to
`GAE_MINOR_VERSION`) will be used as the default value of
`minorVersion_`.

Note that the `GAE_DEPLOYMENT_ID` environment
variable is now set on AppEngine Flex.