### PR TITLE
chore: remove js-green-licenses.json

### DIFF
--- a/js-green-licenses.json
+++ b/js-green-licenses.json
@@ -1,5 +1,0 @@
-{
-  "packageWhitelist": [
-    "log-driver"
-  ]
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -585,7 +585,6 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
-<<<<<<< HEAD
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -611,8 +610,6 @@
         }
       }
     },
-=======
->>>>>>> chore: remove js-green-licenses.json
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
@@ -1471,12 +1468,6 @@
             "color-convert": "1.9.1"
           }
         },
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
         "chalk": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
@@ -1486,20 +1477,6 @@
             "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
             "supports-color": "5.3.0"
-<<<<<<< HEAD
-=======
-          }
-        },
-        "clang-format": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.2.2.tgz",
-          "integrity": "sha512-6X9u1JBMak/9VbC0IZajEDvp19/PbjCanbRO3Z2xsluypQtbPPAGDvGGovLOWoUpXIvJH9vJExmzlqWvwItZxA==",
-          "dev": true,
-          "requires": {
-            "async": "1.5.2",
-            "glob": "7.1.2",
-            "resolve": "1.1.7"
->>>>>>> chore: remove js-green-licenses.json
           }
         },
         "supports-color": {
@@ -1999,11 +1976,7 @@
       "integrity": "sha512-HM/SKwAl1R0y9kkBili6GqKc31ZnjzY7JHC2uO9bAHJNRmY5c/s+2cETyaqX0kBD8gX8QVhS4dJjRtY1nAwb4w==",
       "dev": true,
       "requires": {
-<<<<<<< HEAD
         "argparse": "1.0.10",
-=======
-        "argparse": "1.0.9",
->>>>>>> chore: remove js-green-licenses.json
         "axios": "0.18.0",
         "npm-package-arg": "6.0.0",
         "package-json": "4.0.1",
@@ -2011,99 +1984,6 @@
         "spdx-correct": "3.0.0",
         "spdx-satisfies": "4.0.0",
         "strip-json-comments": "2.0.1"
-<<<<<<< HEAD
-=======
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.18.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-          "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
-          "dev": true,
-          "requires": {
-            "follow-redirects": "1.4.1",
-            "is-buffer": "1.1.6"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
-          "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
-          "dev": true,
-          "requires": {
-            "debug": "3.1.0"
-          }
-        },
-        "spdx-compare": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-1.0.0.tgz",
-          "integrity": "sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==",
-          "dev": true,
-          "requires": {
-            "array-find-index": "1.0.2",
-            "spdx-expression-parse": "3.0.0",
-            "spdx-ranges": "2.0.0"
-          }
-        },
-        "spdx-correct": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
-          "dev": true,
-          "requires": {
-            "spdx-expression-parse": "3.0.0",
-            "spdx-license-ids": "3.0.0"
-          }
-        },
-        "spdx-exceptions": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-          "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
-          "dev": true
-        },
-        "spdx-expression-parse": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-          "dev": true,
-          "requires": {
-            "spdx-exceptions": "2.1.0",
-            "spdx-license-ids": "3.0.0"
-          }
-        },
-        "spdx-license-ids": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-          "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
-          "dev": true
-        },
-        "spdx-ranges": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.0.0.tgz",
-          "integrity": "sha512-AUUXLfqkwD7GlzZkXv8ePPCpPjeVWI9xJCfysL8re/uKb6H10umMnC7bFRsHmLJan4fslUtekAgpHlSgLc/7mA==",
-          "dev": true
-        },
-        "spdx-satisfies": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-4.0.0.tgz",
-          "integrity": "sha512-OcARj6U1OuVv98SVrRqgrR30sVocONtoPpnX8Xz4vXNrFVedqtbgkA+0KmQoXIQ2xjfltPPRVIMeNzKEFLWWKQ==",
-          "dev": true,
-          "requires": {
-            "spdx-compare": "1.0.0",
-            "spdx-expression-parse": "3.0.0",
-            "spdx-ranges": "2.0.0"
-          }
-        }
->>>>>>> chore: remove js-green-licenses.json
       }
     },
     "js-tokens": {
@@ -3159,7 +3039,6 @@
         "source-map": "0.6.1"
       }
     },
-<<<<<<< HEAD
     "spdx-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-1.0.0.tgz",
@@ -3171,8 +3050,6 @@
         "spdx-ranges": "2.0.0"
       }
     },
-=======
->>>>>>> chore: remove js-green-licenses.json
     "spdx-correct": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
@@ -3183,15 +3060,12 @@
         "spdx-license-ids": "3.0.0"
       }
     },
-<<<<<<< HEAD
     "spdx-exceptions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
       "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
       "dev": true
     },
-=======
->>>>>>> chore: remove js-green-licenses.json
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
@@ -3208,7 +3082,6 @@
       "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
       "dev": true
     },
-<<<<<<< HEAD
     "spdx-ranges": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.0.0.tgz",
@@ -3226,8 +3099,6 @@
         "spdx-ranges": "2.0.0"
       }
     },
-=======
->>>>>>> chore: remove js-green-licenses.json
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -585,6 +585,7 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
+<<<<<<< HEAD
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -610,6 +611,8 @@
         }
       }
     },
+=======
+>>>>>>> chore: remove js-green-licenses.json
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
@@ -1468,6 +1471,12 @@
             "color-convert": "1.9.1"
           }
         },
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
         "chalk": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
@@ -1477,6 +1486,20 @@
             "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
             "supports-color": "5.3.0"
+<<<<<<< HEAD
+=======
+          }
+        },
+        "clang-format": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.2.2.tgz",
+          "integrity": "sha512-6X9u1JBMak/9VbC0IZajEDvp19/PbjCanbRO3Z2xsluypQtbPPAGDvGGovLOWoUpXIvJH9vJExmzlqWvwItZxA==",
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "glob": "7.1.2",
+            "resolve": "1.1.7"
+>>>>>>> chore: remove js-green-licenses.json
           }
         },
         "supports-color": {
@@ -1976,7 +1999,11 @@
       "integrity": "sha512-HM/SKwAl1R0y9kkBili6GqKc31ZnjzY7JHC2uO9bAHJNRmY5c/s+2cETyaqX0kBD8gX8QVhS4dJjRtY1nAwb4w==",
       "dev": true,
       "requires": {
+<<<<<<< HEAD
         "argparse": "1.0.10",
+=======
+        "argparse": "1.0.9",
+>>>>>>> chore: remove js-green-licenses.json
         "axios": "0.18.0",
         "npm-package-arg": "6.0.0",
         "package-json": "4.0.1",
@@ -1984,6 +2011,99 @@
         "spdx-correct": "3.0.0",
         "spdx-satisfies": "4.0.0",
         "strip-json-comments": "2.0.1"
+<<<<<<< HEAD
+=======
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+          "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "1.4.1",
+            "is-buffer": "1.1.6"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+          "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+          "dev": true,
+          "requires": {
+            "debug": "3.1.0"
+          }
+        },
+        "spdx-compare": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-1.0.0.tgz",
+          "integrity": "sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==",
+          "dev": true,
+          "requires": {
+            "array-find-index": "1.0.2",
+            "spdx-expression-parse": "3.0.0",
+            "spdx-ranges": "2.0.0"
+          }
+        },
+        "spdx-correct": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+          "dev": true,
+          "requires": {
+            "spdx-expression-parse": "3.0.0",
+            "spdx-license-ids": "3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+          "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+          "dev": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "2.1.0",
+            "spdx-license-ids": "3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+          "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+          "dev": true
+        },
+        "spdx-ranges": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.0.0.tgz",
+          "integrity": "sha512-AUUXLfqkwD7GlzZkXv8ePPCpPjeVWI9xJCfysL8re/uKb6H10umMnC7bFRsHmLJan4fslUtekAgpHlSgLc/7mA==",
+          "dev": true
+        },
+        "spdx-satisfies": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-4.0.0.tgz",
+          "integrity": "sha512-OcARj6U1OuVv98SVrRqgrR30sVocONtoPpnX8Xz4vXNrFVedqtbgkA+0KmQoXIQ2xjfltPPRVIMeNzKEFLWWKQ==",
+          "dev": true,
+          "requires": {
+            "spdx-compare": "1.0.0",
+            "spdx-expression-parse": "3.0.0",
+            "spdx-ranges": "2.0.0"
+          }
+        }
+>>>>>>> chore: remove js-green-licenses.json
       }
     },
     "js-tokens": {
@@ -3039,6 +3159,7 @@
         "source-map": "0.6.1"
       }
     },
+<<<<<<< HEAD
     "spdx-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-1.0.0.tgz",
@@ -3050,6 +3171,8 @@
         "spdx-ranges": "2.0.0"
       }
     },
+=======
+>>>>>>> chore: remove js-green-licenses.json
     "spdx-correct": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
@@ -3060,12 +3183,15 @@
         "spdx-license-ids": "3.0.0"
       }
     },
+<<<<<<< HEAD
     "spdx-exceptions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
       "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
       "dev": true
     },
+=======
+>>>>>>> chore: remove js-green-licenses.json
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
@@ -3082,6 +3208,7 @@
       "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
       "dev": true
     },
+<<<<<<< HEAD
     "spdx-ranges": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.0.0.tgz",
@@ -3099,6 +3226,8 @@
         "spdx-ranges": "2.0.0"
       }
     },
+=======
+>>>>>>> chore: remove js-green-licenses.json
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",


### PR DESCRIPTION
In particular, `log-driver` no longer needs to be listed.

Fixes #387