### PR TITLE
chore: update semver to `5.5.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "findit2": "^2.2.3",
     "gcp-metadata": "^0.6.3",
     "lodash": "^4.12.0",
-    "semver": "^5.1.0",
+    "semver": "^5.5.0",
     "source-map": "^0.6.1",
     "split": "^1.0.0",
     "util.promisify": "^1.0.0"


### PR DESCRIPTION
The current `package.json` requires `semver@'^5.1.0'`.  However,
the `semver.coerce` function does not exist in that version.

As part of PR #407, `package-lock.json` was regenerated and
specified semver version 5.5.0 should be used.

When the tests were run, Node >= 8 would use package-lock.json
and installed semver 5.5.0 that has `semver.coerce`.

In addition, for Node < 8, the tests would install the latest
version of semver (5.5.0) that has `semver.coerce`.

As a result, the system and unit tests would all pass.

However, if user code, or the code of its dependencies, requires
only semver@'^5.1.0', and that version was installed prior to
installing @google-cloud/debug-agent, version `5.1.0` of semver
could be used.  However since this version doesn't have the
`semver.coerce` function, the debug agent would crash on
startup.  This is what happened in issue #420.

Fixes: #420