### PR TITLE
chore: remove the GCLOUD_USE_INSPECTOR env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,19 +176,6 @@ Further, you do not need to deploy the original source files to the deployment e
 
 In the Debug UI, you only need to provide the original source code -- you don't need the transpiled output files or the sourcemaps. When you set a snapshot in an original source file in the Debug UI, the corresponding file and line in the transpiled code is automatically determined based on the sourcemap files provided with the transpiled code at runtime.  See the [Using the Debugger](#using-the-debugger) section for more information about using the Debug UI.  In addition, the exact directory layout of the original source is somewhat flexible, just as it is with the use of non-transpiled code as described in the [Using the Debugger](#using-the-debugger) section.
 
-## Experimental Features
-
-The Stackdriver Debugger includes experimental support for the new [V8 Inspector Protocol](https://chromedevtools.github.io/debugger-protocol-viewer/v8/) and will use it if and only if the `GCLOUD_USE_INSPECTOR` environment variable is set and the running version of Node supports the inspector protocol (Node 8+).
-
-If the `GCLOUD_USE_INSPECTOR` environment variable is set, but the running version of Node does not support the inspector protocol, the agent will fall back to the legacy debugger protocol and a warning message will be logged.
-
-The `GCLOUD_USE_INSPECTOR` can be set programmatically, but must be set before calling the `start` method as illustrated below:
-
-```js
-process.env['GCLOUD_USE_INSPECTOR'] = true;
-require('@google-cloud/debug-agent').start({ ... });
-```
-
 ## Using Stackdriver Debugger on Google Cloud Functions
 
 The Stackdriver Debugger also introduces a new `isReady` method that returns a `Promise` that is resolved in either of the three scenarios.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,9 +20,6 @@ install:
 test_script:
   # run tests
   - npm run compile
-  - SET GCLOUD_USE_INSPECTOR=
-  - node_modules/.bin/mocha build/test --timeout 4000 --R
-  - SET GCLOUD_USE_INSPECTOR=1
   - node_modules/.bin/mocha build/test --timeout 4000 --R
 
 # Don't actually build using MSBuild

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -30,8 +30,7 @@ function run {
 }
 
 # Run test/coverage
-GCLOUD_USE_INSPECTOR= run build/test
-GCLOUD_USE_INSPECTOR=true run build/test
+run build/test
 
 # Conditionally publish coverage
 if [ "$cover" ]; then

--- a/src/agent/util/utils.ts
+++ b/src/agent/util/utils.ts
@@ -25,9 +25,7 @@ export const messages = {
   CAPTURE_BREAKPOINT_DATA: 'Error trying to capture snapshot data: ',
   INVALID_LINE_NUMBER: 'Invalid snapshot position: ',
   COULD_NOT_FIND_OUTPUT_FILE:
-      'Could not determine the output file associated with the transpiled input file',
-  INSPECTOR_NOT_AVAILABLE:
-      'The V8 Inspector protocol is only available in Node 8+'
+      'Could not determine the output file associated with the transpiled input file'
 };
 
 export interface Listener {

--- a/src/agent/v8/debugapi.ts
+++ b/src/agent/v8/debugapi.ts
@@ -42,14 +42,9 @@ interface DebugApiConstructor {
 
 let debugApiConstructor: DebugApiConstructor;
 
-export function willUseInspector(nodeVersion?: string, useInspector?: boolean) {
+export function willUseInspector(nodeVersion?: string) {
   const version = nodeVersion != null ? nodeVersion : process.version;
-  const node10Above = utils.satisfies(version, '>=10');
-  const node8Above = utils.satisfies(version, '>=8');
-  const resolvedUseInspector =
-      useInspector != null ? useInspector : !!process.env.GCLOUD_USE_INSPECTOR;
-
-  return node10Above || (node8Above && resolvedUseInspector);
+  return utils.satisfies(version, '>=10');
 }
 
 if (willUseInspector()) {

--- a/src/agent/v8/legacy-debugapi.ts
+++ b/src/agent/v8/legacy-debugapi.ts
@@ -90,9 +90,6 @@ export class V8DebugApi implements debugapi.DebugApi {
             this.logger.warn('Internal V8 error on breakpoint event: ' + e);
           }
         };
-    if (process.env.GCLOUD_USE_INSPECTOR) {
-      this.logger.warn(utils.messages.INSPECTOR_NOT_AVAILABLE);
-    }
     if (this.usePermanentListener) {
       this.logger.info('activating v8 breakpoint listener (permanent)');
 


### PR DESCRIPTION
Now the inspector protocol is necessarily used for Node >= 10 and
the legacy protocol is used for Node < 10.