### PR TITLE
fix: stop testing node 4 on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@
 environment:
   matrix:
   # node.js
-  - nodejs_version: "4"
   - nodejs_version: "6"
   - nodejs_version: "8"
   - nodejs_version: "10"


### PR DESCRIPTION
I missed this one in #440 