### PR TITLE
feat: accept SourceContext in config

### DIFF
--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -20,6 +20,52 @@ export type DebugAgentConfig = {
   [K in keyof ResolvedDebugAgentConfig]?: Partial<ResolvedDebugAgentConfig[K]>
 };
 
+export interface ProjectRepoId {
+  projectId: string;
+  repoName: string;
+}
+
+export interface RepoId {
+  projectRepoId: ProjectRepoId;
+  uid: string;
+}
+
+export interface AliasContext {
+  kind: 'ANY'|'FIXED'|'MOVABLE'|'OTHER';
+  name: string;
+}
+
+export interface CloudRepoSourceContext {
+  repoId: RepoId;
+  revisionId: string;
+  aliasName?: string;
+  aliasContext: AliasContext;
+}
+
+export interface CloudWorkspaceId {
+  repoId: RepoId;
+  name: string;
+}
+
+export interface CloudWorkspaceSourceContext {
+  workspaceId: CloudWorkspaceId;
+  snapshotId: string;
+}
+
+export interface GerritSourceContext {
+  hostUri: string;
+  gerritProject: string;
+  // one of:
+  revisionId?: string;
+  aliasName?: string;
+  aliasContext?: AliasContext;
+}
+
+export interface GitSourceContext {
+  url: string;
+  revisionId: string;
+}
+
 export interface ResolvedDebugAgentConfig extends common.AuthenticationConfig {
   /**
    * Specifies the working directory of the application being
@@ -82,6 +128,21 @@ export interface ResolvedDebugAgentConfig extends common.AuthenticationConfig {
      */
     minorVersion_?: string;
   };
+
+  /**
+   * A SourceContext is a reference to a tree of files. A SourceContext together
+   * with a path point to a unique version of a single file or directory.
+   * Managed environments such as AppEngine generate a source-contexts.json file
+   * at deployment time. The agent can load the SourceContext from that file if
+   * it exists. In other environments, e.g. locally, GKE, GCE, AWS, etc., users
+   * can either generate the source context file, or pass the context as part of
+   * the agent configuration.
+   *
+   * @link
+   * https://cloud.google.com/debugger/api/reference/rest/v2/Debuggee#SourceContext
+   */
+  sourceContext?: CloudRepoSourceContext|CloudWorkspaceSourceContext|
+      GerritSourceContext|GitSourceContext;
 
   /**
    * The path within your repository to the directory

--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -375,7 +375,8 @@ export class Debuglet extends EventEmitter {
 
     let sourceContext;
     try {
-      sourceContext = await Debuglet.getSourceContextFromFile();
+      sourceContext = that.config.sourceContext as {} as SourceContext ||
+          await Debuglet.getSourceContextFromFile();
     } catch (err5) {
       that.logger.warn('Unable to discover source context', err5);
       // This is ignorable.
@@ -435,7 +436,7 @@ export class Debuglet extends EventEmitter {
       projectId: string, uid: string,
       serviceContext:
           {service?: string, version?: string, minorVersion_?: string},
-      sourceContext: {[key: string]: string}|undefined, onGCP: boolean,
+      sourceContext: SourceContext|undefined, onGCP: boolean,
       packageInfo: PackageInfo, description?: string,
       errorMessage?: string): Debuggee {
     const cwd = process.cwd();
@@ -1018,7 +1019,7 @@ export class Debuglet extends EventEmitter {
 
   static _createUniquifier(
       desc: string, version: string, uid: string,
-      sourceContext: {[key: string]: {}}|undefined,
+      sourceContext: SourceContext|undefined,
       labels: {[key: string]: string}): string {
     const uniquifier = desc + version + uid + JSON.stringify(sourceContext) +
         JSON.stringify(labels);

--- a/system-test/test-e2e.ts
+++ b/system-test/test-e2e.ts
@@ -19,9 +19,9 @@ import * as cp from 'child_process';
 import * as _ from 'lodash';  // for _.find. Can't use ES6 yet.
 import * as util from 'util';
 
-import * as stackdriver from '../src/types/stackdriver';
 import {Debug} from '../src/client/stackdriver/debug';
 import {Debuggee} from '../src/debuggee';
+import * as stackdriver from '../src/types/stackdriver';
 import {Debugger} from '../test/debugger';
 
 const CLUSTER_WORKERS = 3;


### PR DESCRIPTION
In preference to looking for a well-known source-contexts.json file, we
now accept sourceContext as part of the config as well.

Fixes: https://github.com/GoogleCloudPlatform/cloud-debug-nodejs/issues/459