### PR TITLE
test: use unique api url per nock

### DIFF
--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -259,7 +259,7 @@ export interface ResolvedDebugAgentConfig extends GoogleAuthOptions {
   testMode_: boolean;
 
   /**
-   * used by tests that nock to isolate nocks to their own scopes.
+   * used to set a default api url
    */
   apiUrl?: string;
 }

--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -257,6 +257,11 @@ export interface ResolvedDebugAgentConfig extends GoogleAuthOptions {
    * Uses by tests to cause the start() function to return the debuglet.
    */
   testMode_: boolean;
+
+  /**
+   * used by tests that nock to isolate nocks to their own scopes.
+   */
+  apiUrl?: string;
 }
 
 export interface StackdriverConfig extends GoogleAuthOptions {

--- a/src/agent/controller.ts
+++ b/src/agent/controller.ts
@@ -20,7 +20,6 @@
 
 import {ServiceObject} from '@google-cloud/common';
 import * as assert from 'assert';
-import * as http from 'http';
 import * as qs from 'querystring';
 import {Response} from 'request';
 import {URL} from 'url';

--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -233,7 +233,7 @@ export class Debuglet extends EventEmitter {
     });
 
     /** @private {DebugletApi} */
-    this.controller = new Controller(this.debug);
+    this.controller = new Controller(this.debug, {apiUrl: config.apiUrl});
 
     /** @private {Debuggee} */
     this.debuggee = null;

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -30,11 +30,9 @@ DEFAULT_CONFIG.workingDirectory = path.join(__dirname, '..', '..');
 import {Debuglet, CachedPromise, FindFilesResult} from '../src/agent/debuglet';
 import {ScanResults} from '../src/agent/io/scanner';
 import * as extend from 'extend';
-
 import {Debug} from '../src/client/stackdriver/debug';
 
 const DEBUGGEE_ID = 'bar';
-const API = 'https://clouddebugger.googleapis.com';
 const REGISTER_PATH = '/v2/controller/debuggees/register';
 const BPS_PATH = '/v2/controller/debuggees/' + DEBUGGEE_ID + '/breakpoints';
 const EXPRESSIONS_REGEX =
@@ -1371,7 +1369,7 @@ let apiUrlInc = 0;
  * @param conf custom config values
  */
 function debugletConfig(conf?: {}): (ResolvedDebugAgentConfig & {apiUrl:string}) {
-  const apiUrl = API + (++apiUrlInc);
+  const apiUrl = 'https://clouddebugger.googleapis.com' + (++apiUrlInc);
   const c = Object.assign({}, DEFAULT_CONFIG, conf) as (ResolvedDebugAgentConfig & {apiUrl:string});
   c.apiUrl = apiUrl;
   return c;

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -1368,9 +1368,11 @@ let apiUrlInc = 0;
  * returns a new config object to be passed to debuglet. always has apiUrl
  * @param conf custom config values
  */
-function debugletConfig(conf?: {}): (ResolvedDebugAgentConfig & {apiUrl:string}) {
+function debugletConfig(conf?: {}): (ResolvedDebugAgentConfig&
+                                     {apiUrl: string}) {
   const apiUrl = 'https://clouddebugger.googleapis.com' + (++apiUrlInc);
-  const c = Object.assign({}, DEFAULT_CONFIG, conf) as (ResolvedDebugAgentConfig & {apiUrl:string});
+  const c = Object.assign({}, DEFAULT_CONFIG, conf) as (
+                ResolvedDebugAgentConfig & {apiUrl: string});
   c.apiUrl = apiUrl;
   return c;
 }

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -20,7 +20,7 @@ import * as _ from 'lodash';
 import * as path from 'path';
 import * as proxyquire from 'proxyquire';
 
-import {DebugAgentConfig} from '../src/agent/config';
+import {DebugAgentConfig, ResolvedDebugAgentConfig} from '../src/agent/config';
 import {defaultConfig as DEFAULT_CONFIG} from '../src/agent/config';
 import {Debuggee} from '../src/debuggee';
 import * as stackdriver from '../src/types/stackdriver';
@@ -75,6 +75,7 @@ function verifyBreakpointRejection(
   return status!.isError && hasCorrectDescription;
 }
 
+
 describe('CachedPromise', () => {
   it('CachedPromise.get() will resolve after CachedPromise.resolve()',
      function(done) {
@@ -119,6 +120,7 @@ describe('Debuglet', () => {
     after(() => {
       process.env.GCLOUD_PROJECT = oldGP;
     });
+
     beforeEach(() => {
       delete process.env.GCLOUD_PROJECT;
       nocks.oauth2();
@@ -222,10 +224,12 @@ describe('Debuglet', () => {
       const projectId = '11020304f2934-a';
       const debug =
           new Debug({projectId, credentials: fakeCredentials}, packageInfo);
-      const debuglet = new Debuglet(debug, defaultConfig);
 
       nocks.projectId('project-via-metadata');
-      const scope = nock(API).post(REGISTER_PATH).reply(200, {
+
+      const config = debugletConfig();
+      const debuglet = new Debuglet(debug, config);
+      const scope = nock(config.apiUrl).post(REGISTER_PATH).reply(200, {
         debuggee: {id: DEBUGGEE_ID}
       });
 
@@ -316,10 +320,12 @@ describe('Debuglet', () => {
       it('should use GCLOUD_PROJECT in lieu of config.projectId', (done) => {
         process.env.GCLOUD_PROJECT = '11020304f2934-b';
         const debug = new Debug({credentials: fakeCredentials}, packageInfo);
-        const debuglet = new Debuglet(debug, defaultConfig);
 
         nocks.projectId('project-via-metadata');
-        const scope = nock(API).post(REGISTER_PATH).reply(200, {
+
+        const config = debugletConfig();
+        const debuglet = new Debuglet(debug, config);
+        const scope = nock(config.apiUrl).post(REGISTER_PATH).reply(200, {
           debuggee: {id: DEBUGGEE_ID}
         });
 
@@ -341,10 +347,12 @@ describe('Debuglet', () => {
            const debug = new Debug(
                {projectId: 'project-via-options', credentials: fakeCredentials},
                packageInfo);
-           const debuglet = new Debuglet(debug, defaultConfig);
 
            nocks.projectId('project-via-metadata');
-           const scope = nock(API).post(REGISTER_PATH).reply(200, {
+
+           const config = debugletConfig();
+           const debuglet = new Debuglet(debug, config);
+           const scope = nock(config.apiUrl).post(REGISTER_PATH).reply(200, {
              debuggee: {id: DEBUGGEE_ID}
            });
 
@@ -364,10 +372,12 @@ describe('Debuglet', () => {
         process.env.GCLOUD_PROJECT = '11020304f2934';
         process.env.GCLOUD_DEBUG_LOGLEVEL = '3';
         const debug = new Debug({credentials: fakeCredentials}, packageInfo);
-        const debuglet = new Debuglet(debug, defaultConfig);
 
         nocks.projectId('project-via-metadata');
-        const scope = nock(API).post(REGISTER_PATH).reply(200, {
+
+        const config = debugletConfig();
+        const debuglet = new Debuglet(debug, config);
+        const scope = nock(config.apiUrl).post(REGISTER_PATH).reply(200, {
           debuggee: {id: DEBUGGEE_ID}
         });
 
@@ -504,9 +514,10 @@ describe('Debuglet', () => {
            const debug = new Debug(
                {projectId: 'fake-project', credentials: fakeCredentials},
                packageInfo);
-           const debuglet = new Debuglet(debug, defaultConfig);
 
-           const scope = nock(API)
+           const config = debugletConfig();
+           const debuglet = new Debuglet(debug, config);
+           const scope = nock(config.apiUrl)
                              .post(
                                  REGISTER_PATH,
                                  (body: {debuggee: Debuggee}) => {
@@ -532,9 +543,10 @@ describe('Debuglet', () => {
       const debug = new Debug(
           {projectId: '11020304f2934', credentials: fakeCredentials},
           packageInfo);
-      const debuglet = new Debuglet(debug, defaultConfig);
 
-      const scope = nock(API)
+      const config = debugletConfig();
+      const debuglet = new Debuglet(debug, config);
+      const scope = nock(config.apiUrl)
                         .post(REGISTER_PATH)
                         .reply(404)
                         .post(REGISTER_PATH)
@@ -691,10 +703,12 @@ describe('Debuglet', () => {
       const debug = new Debug(
           {projectId: 'fake-project', credentials: fakeCredentials},
           packageInfo);
-      const debuglet = new Debuglet(debug, defaultConfig);
 
       nocks.oauth2();
-      const scope = nock(API).post(REGISTER_PATH).reply(200, {
+
+      const config = debugletConfig();
+      const debuglet = new Debuglet(debug, config);
+      const scope = nock(config.apiUrl).post(REGISTER_PATH).reply(200, {
         debuggee: {id: DEBUGGEE_ID}
       });
 
@@ -722,10 +736,12 @@ describe('Debuglet', () => {
       const debug = new Debug(
           {projectId: 'fake-project', credentials: fakeCredentials},
           packageInfo);
-      const debuglet = new Debuglet(debug, defaultConfig);
 
       nocks.oauth2();
-      const scope = nock(API).post(REGISTER_PATH).reply(200, {
+
+      const config = debugletConfig();
+      const debuglet = new Debuglet(debug, config);
+      const scope = nock(config.apiUrl).post(REGISTER_PATH).reply(200, {
         debuggee: {id: DEBUGGEE_ID}
       });
 
@@ -749,12 +765,11 @@ describe('Debuglet', () => {
       const debug = new Debug(
           {projectId: 'fake-project', credentials: fakeCredentials},
           packageInfo);
-      const config = extend(
-          {}, defaultConfig,
+
+      const config = debugletConfig(
           {sourceContext: {url: REPO_URL, revisionId: REVISION_ID}});
       const debuglet = new Debuglet(debug, config);
-
-      const scope = nock(API)
+      const scope = nock(config.apiUrl)
                         .post(
                             REGISTER_PATH,
                             (body: {debuggee: Debuggee}) => {
@@ -782,9 +797,10 @@ describe('Debuglet', () => {
       Debuglet.getSourceContextFromFile = async () => {
         return {a: 5 as {} as string};
       };
-      const debuglet = new Debuglet(debug, defaultConfig);
 
-      const scope = nock(API)
+      const config = debugletConfig();
+      const debuglet = new Debuglet(debug, config);
+      const scope = nock(config.apiUrl)
                         .post(
                             REGISTER_PATH,
                             (body: {debuggee: Debuggee}) => {
@@ -812,16 +828,16 @@ describe('Debuglet', () => {
       const debug = new Debug(
           {projectId: 'fake-project', credentials: fakeCredentials},
           packageInfo);
-      const config = extend(
-          {}, defaultConfig,
-          {sourceContext: {url: REPO_URL, revisionId: REVISION_ID}});
+
       const old = Debuglet.getSourceContextFromFile;
       Debuglet.getSourceContextFromFile = async () => {
         return {a: 5 as {} as string};
       };
-      const debuglet = new Debuglet(debug, config);
 
-      const scope = nock(API)
+      const config = debugletConfig(
+          {sourceContext: {url: REPO_URL, revisionId: REVISION_ID}});
+      const debuglet = new Debuglet(debug, config);
+      const scope = nock(config.apiUrl)
                         .post(
                             REGISTER_PATH,
                             (body: {debuggee: Debuggee}) => {
@@ -848,9 +864,10 @@ describe('Debuglet', () => {
          const debug = new Debug(
              {projectId: 'fake-project', credentials: fakeCredentials},
              packageInfo);
-         const debuglet = new Debuglet(debug, defaultConfig);
 
-         const scope = nock(API).post(REGISTER_PATH).reply(200, {
+         const config = debugletConfig();
+         const debuglet = new Debuglet(debug, config);
+         const scope = nock(config.apiUrl).post(REGISTER_PATH).reply(200, {
            debuggee: {id: DEBUGGEE_ID, isDisabled: true}
          });
 
@@ -869,10 +886,11 @@ describe('Debuglet', () => {
       const debug = new Debug(
           {projectId: 'fake-project', credentials: fakeCredentials},
           packageInfo);
-      const debuglet = new Debuglet(debug, defaultConfig);
 
+      const config = debugletConfig();
+      const debuglet = new Debuglet(debug, config);
       const scope =
-          nock(API)
+          nock(config.apiUrl)
               .post(REGISTER_PATH)
               .reply(200, {debuggee: {id: DEBUGGEE_ID, isDisabled: true}})
               .post(REGISTER_PATH)
@@ -899,9 +917,9 @@ describe('Debuglet', () => {
       const debug = new Debug(
           {projectId: 'fake-project', credentials: fakeCredentials},
           packageInfo);
-      const debuglet = new Debuglet(debug, defaultConfig);
-
-      const scope = nock(API)
+      const config = debugletConfig();
+      const debuglet = new Debuglet(debug, config);
+      const scope = nock(config.apiUrl)
                         .post(REGISTER_PATH)
                         .reply(200, {debuggee: {id: DEBUGGEE_ID}})
                         .get(BPS_PATH + '?successOnTimeout=true')
@@ -927,9 +945,9 @@ describe('Debuglet', () => {
       const debug = new Debug(
           {projectId: 'fake-project', credentials: fakeCredentials},
           packageInfo);
-      const debuglet = new Debuglet(debug, defaultConfig);
-
-      const scope = nock(API)
+      const config = debugletConfig();
+      const debuglet = new Debuglet(debug, config);
+      const scope = nock(config.apiUrl)
                         .post(REGISTER_PATH)
                         .reply(200, {debuggee: {id: DEBUGGEE_ID}})
                         .get(BPS_PATH + '?successOnTimeout=true')
@@ -960,9 +978,10 @@ describe('Debuglet', () => {
          const debug = new Debug(
              {projectId: 'fake-project', credentials: fakeCredentials},
              packageInfo);
-         const debuglet = new Debuglet(debug, defaultConfig);
 
-         const scope = nock(API)
+         const config = debugletConfig();
+         const debuglet = new Debuglet(debug, config);
+         const scope = nock(config.apiUrl)
                            .post(REGISTER_PATH)
                            .reply(200, {debuggee: {id: DEBUGGEE_ID}})
                            .get(BPS_PATH + '?successOnTimeout=true')
@@ -974,7 +993,8 @@ describe('Debuglet', () => {
              // Once debugPromise is resolved, debuggee must be registered.
              assert(debuglet.debuggee);
              setTimeout(() => {
-               assert.deepStrictEqual(debuglet.activeBreakpointMap.test1, breakpoint);
+               assert.deepStrictEqual(
+                   debuglet.activeBreakpointMap.test1, breakpoint);
                debuglet.activeBreakpointMap = {};
                debuglet.stop();
                scope.done();
@@ -991,9 +1011,13 @@ describe('Debuglet', () => {
          const debug = new Debug(
              {projectId: 'fake-project', credentials: fakeCredentials},
              packageInfo);
-         const debuglet = new Debuglet(debug, defaultConfig);
 
-         const scope = nock(API)
+         // const debuglet = new Debuglet(debug, defaultConfig);
+         // const scope = nock(API)
+         /// this change to a unique scope per test causes
+         const config = debugletConfig();
+         const debuglet = new Debuglet(debug, config);
+         const scope = nock(config.apiUrl)
                            .post(REGISTER_PATH)
                            .reply(200, {debuggee: {id: DEBUGGEE_ID}})
                            .get(BPS_PATH + '?successOnTimeout=true')
@@ -1014,11 +1038,11 @@ describe('Debuglet', () => {
          const debug = new Debug(
              {projectId: 'fake-project', credentials: fakeCredentials},
              packageInfo);
-         const debuglet = new Debuglet(debug, defaultConfig);
-         debuglet.config.allowExpressions = false;
 
+         const config = debugletConfig({allowExpressions: false});
+         const debuglet = new Debuglet(debug, config);
          const scope =
-             nock(API)
+             nock(config.apiUrl)
                  .post(REGISTER_PATH)
                  .reply(200, {debuggee: {id: DEBUGGEE_ID}})
                  .get(BPS_PATH + '?successOnTimeout=true')
@@ -1055,11 +1079,11 @@ describe('Debuglet', () => {
          const debug = new Debug(
              {projectId: 'fake-project', credentials: fakeCredentials},
              packageInfo);
-         const debuglet = new Debuglet(debug, defaultConfig);
-         debuglet.config.allowExpressions = false;
 
+         const config = debugletConfig({allowExpressions: false});
+         const debuglet = new Debuglet(debug, config);
          const scope =
-             nock(API)
+             nock(config.apiUrl)
                  .post(REGISTER_PATH)
                  .reply(200, {debuggee: {id: DEBUGGEE_ID}})
                  .get(BPS_PATH + '?successOnTimeout=true')
@@ -1096,9 +1120,10 @@ describe('Debuglet', () => {
       const debug = new Debug(
           {projectId: 'fake-project', credentials: fakeCredentials},
           packageInfo);
-      const debuglet = new Debuglet(debug, defaultConfig);
 
-      const scope = nock(API)
+      const config = debugletConfig();
+      const debuglet = new Debuglet(debug, config);
+      const scope = nock(config.apiUrl)
                         .post(REGISTER_PATH)
                         .reply(200, {debuggee: {id: DEBUGGEE_ID}})
                         .post(REGISTER_PATH)
@@ -1137,12 +1162,13 @@ describe('Debuglet', () => {
       const debug = new Debug(
           {projectId: 'fake-project', credentials: fakeCredentials},
           packageInfo);
-      const config = extend(
-          {}, defaultConfig,
-          {breakpointExpirationSec: 1, forceNewAgent_: true});
+
       this.timeout(6000);
 
-      const scope = nock(API)
+      const config =
+          debugletConfig({breakpointExpirationSec: 1, forceNewAgent_: true});
+      const debuglet = new Debuglet(debug, config);
+      const scope = nock(config.apiUrl)
                         .post(REGISTER_PATH)
                         .reply(200, {debuggee: {id: DEBUGGEE_ID}})
                         .get(BPS_PATH + '?successOnTimeout=true')
@@ -1157,7 +1183,6 @@ describe('Debuglet', () => {
                             })
                         .reply(200);
 
-      const debuglet = new Debuglet(debug, config);
       debuglet.once('registered', (id: string) => {
         assert.strictEqual(id, DEBUGGEE_ID);
         setTimeout(() => {
@@ -1185,15 +1210,17 @@ describe('Debuglet', () => {
       const debug = new Debug(
           {projectId: 'fake-project', credentials: fakeCredentials},
           packageInfo);
-      const config = extend({}, defaultConfig, {
+
+      this.timeout(6000);
+
+      const config = debugletConfig({
         breakpointExpirationSec: 1,
         breakpointUpdateIntervalSec: 1,
         forceNewAgent_: true
       });
-      this.timeout(6000);
-
+      const debuglet = new Debuglet(debug, config);
       const scope =
-          nock(API)
+          nock(config.apiUrl)
               .post(REGISTER_PATH)
               .reply(200, {debuggee: {id: DEBUGGEE_ID}})
               .get(BPS_PATH + '?successOnTimeout=true')
@@ -1209,7 +1236,6 @@ describe('Debuglet', () => {
               .times(4)
               .reply(200, {breakpoints: [bp]});
 
-      const debuglet = new Debuglet(debug, config);
       debuglet.once('registered', (id: string) => {
         assert.strictEqual(id, DEBUGGEE_ID);
         setTimeout(() => {
@@ -1245,8 +1271,10 @@ describe('Debuglet', () => {
     it('should be correct', () => {
       // TODO: Determine if Debuglet.format() should allow a number[]
       //       or if only string[] should be allowed.
-      assert.deepStrictEqual(Debuglet.format('hi', [5] as {} as string[]), 'hi');
-      assert.deepStrictEqual(Debuglet.format('hi $0', [5] as {} as string[]), 'hi 5');
+      assert.deepStrictEqual(
+          Debuglet.format('hi', [5] as {} as string[]), 'hi');
+      assert.deepStrictEqual(
+          Debuglet.format('hi $0', [5] as {} as string[]), 'hi 5');
       assert.deepStrictEqual(
           Debuglet.format('hi $0 $1', [5, 'there'] as {} as string[]),
           'hi 5 there');
@@ -1254,7 +1282,8 @@ describe('Debuglet', () => {
           Debuglet.format('hi $0 $1', [5] as {} as string[]), 'hi 5 $1');
       assert.deepStrictEqual(
           Debuglet.format('hi $0 $1 $0', [5] as {} as string[]), 'hi 5 $1 5');
-      assert.deepStrictEqual(Debuglet.format('hi $$', [5] as {} as string[]), 'hi $');
+      assert.deepStrictEqual(
+          Debuglet.format('hi $$', [5] as {} as string[]), 'hi $');
       assert.deepStrictEqual(
           Debuglet.format('hi $$0', [5] as {} as string[]), 'hi $0');
       assert.deepStrictEqual(
@@ -1333,3 +1362,17 @@ describe('Debuglet', () => {
     });
   });
 });
+
+// a counter for unique test urls.
+let apiUrlInc = 0;
+
+/**
+ * returns a new config object to be passed to debuglet. always has apiUrl
+ * @param conf custom config values
+ */
+function debugletConfig(conf?: {}): (ResolvedDebugAgentConfig & {apiUrl:string}) {
+  const apiUrl = API + (++apiUrlInc);
+  const c = Object.assign({}, DEFAULT_CONFIG, conf) as (ResolvedDebugAgentConfig & {apiUrl:string});
+  c.apiUrl = apiUrl;
+  return c;
+}


### PR DESCRIPTION
fixes GoogleCloudPlatform/cloud-debug-nodejs#446
i hope =)

this adds the ability to configure the apiUrl used by
src/agent/controller.ts passing through src/agent/debuglet.ts

because debuglet makes or may still have requests open after stop()
 is called. It occasionally triggers nocks for other tests. 
nock is only global so we play its own game by making sure urls from 
one test have no way of matching another.

note: it seems easier to mock out debuglet.controller instead
of depending on nocks.