### PR TITLE
fix: Add debugging information for sourcemapper

### DIFF
--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -359,10 +359,10 @@ export interface ResolvedDebugAgentConfig extends GoogleAuthOptions {
   apiUrl?: string;
 
   /**
-   * Number of times the V8 pauses (could be breakpoint hits) before the
-   * debugging session is reset. This is to release the memory usage held by V8
-   * engine for each breakpoint hit to prevent the memory leak. The default
-   * value is specified in defaultConfig.
+   * Number of times of the V8 breakpoint hits events before resetting the
+   * breakpoints. This is to release the memory usage held by V8 engine for each
+   * breakpoint hit to prevent the memory leak. The default value is specified
+   * in defaultConfig.
    */
   resetV8DebuggerThreshold: number;
 }

--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -396,12 +396,13 @@ export class Debuglet extends EventEmitter {
 
     let mapper;
     try {
-      mapper = await SourceMapper.create(findResults.mapFiles);
+      mapper = await SourceMapper.create(findResults.mapFiles, that.logger);
     } catch (err3) {
       that.logger.error('Error processing the sourcemaps.', err3);
       that.emit('initError', err3);
       return;
     }
+
     that.v8debug = debugapi.create(
       that.logger,
       that.config,

--- a/src/agent/io/sourcemapper.ts
+++ b/src/agent/io/sourcemapper.ts
@@ -327,7 +327,10 @@ export class SourceMapper {
  * @param {Logger} logger A logger that reports errors that occurred while
  *  processing the given sourcemap files
  */
-export async function create(sourcemapPaths: string[], logger: Logger): Promise<SourceMapper> {
+export async function create(
+  sourcemapPaths: string[],
+  logger: Logger
+): Promise<SourceMapper> {
   const limit = pLimit(CONCURRENCY);
   const mapper = new SourceMapper(logger);
   const promises = sourcemapPaths.map(path =>

--- a/src/agent/io/sourcemapper.ts
+++ b/src/agent/io/sourcemapper.ts
@@ -18,6 +18,7 @@ import * as path from 'path';
 import {promisify} from 'util';
 import * as sourceMap from 'source-map';
 
+import {Logger} from '../config';
 import {findScriptsFuzzy} from '../util/utils';
 
 const CONCURRENCY = 10;
@@ -167,17 +168,10 @@ async function processSourcemap(
 }
 
 export class SourceMapper {
+  /** Maps each original source path to the corresponding source map info. */
   infoMap: Map<string, MapInfoInput>;
 
-  /**
-   * @param {Array.<string>} sourcemapPaths An array of paths to .map sourcemap
-   *  files that should be processed.  The paths should be relative to the
-   *  current process's current working directory
-   * @param {Logger} logger A logger that reports errors that occurred while
-   *  processing the given sourcemap files
-   * @constructor
-   */
-  constructor() {
+  constructor(readonly logger: Logger) {
     this.infoMap = new Map();
   }
 
@@ -210,6 +204,8 @@ export class SourceMapper {
       inputPath,
       Array.from(this.infoMap.keys())
     );
+
+    this.logger.debug(`sourcemapper fuzzy matches: ${matches}`);
 
     if (matches.length === 1) {
       return this.infoMap.get(matches[0]) as MapInfoInput;
@@ -246,6 +242,8 @@ export class SourceMapper {
     colNumber: number,
     entry: MapInfoInput
   ): MapInfoOutput | null {
+    this.logger.debug(`sourcemapper inputPath: ${inputPath}`);
+
     inputPath = path.normalize(inputPath);
 
     const relPath = path
@@ -273,6 +271,8 @@ export class SourceMapper {
       column: colNumber, // to be zero-based
     };
 
+    this.logger.debug(`sourcemapper sourcePos: ${JSON.stringify(sourcePos)}`);
+
     const allPos = entry.mapConsumer.allGeneratedPositionsFor(sourcePos);
     /*
      * Based on testing, it appears that the following code is needed to
@@ -290,6 +290,8 @@ export class SourceMapper {
           })
         : entry.mapConsumer.generatedPositionFor(sourcePos);
 
+    this.logger.debug(`sourcemapper mappedPos: ${JSON.stringify(mappedPos)}`);
+
     return {
       file: entry.outputFile,
       line: (mappedPos.line ?? 0) - 1, // convert the one-based line numbers returned
@@ -305,11 +307,29 @@ export class SourceMapper {
       // output
     };
   }
+
+  /** Prints the debugging information of the source mapper to the logger. */
+  debug() {
+    this.logger.debug('Printing source mapper debugging information ...');
+    for (const [key, value] of this.infoMap) {
+      this.logger.debug(`  source ${key}:`);
+      this.logger.debug(`    outputFile: ${value.outputFile}`);
+      this.logger.debug(`    mapFile: ${value.mapFile}`);
+      this.logger.debug(`    sources: ${value.sources}`);
+    }
+  }
 }
 
-export async function create(sourcemapPaths: string[]): Promise<SourceMapper> {
+/**
+ * @param {Array.<string>} sourcemapPaths An array of paths to .map sourcemap
+ *  files that should be processed.  The paths should be relative to the
+ *  current process's current working directory
+ * @param {Logger} logger A logger that reports errors that occurred while
+ *  processing the given sourcemap files
+ */
+export async function create(sourcemapPaths: string[], logger: Logger): Promise<SourceMapper> {
   const limit = pLimit(CONCURRENCY);
-  const mapper = new SourceMapper();
+  const mapper = new SourceMapper(logger);
   const promises = sourcemapPaths.map(path =>
     limit(() => processSourcemap(mapper.infoMap, path))
   );
@@ -320,5 +340,6 @@ export async function create(sourcemapPaths: string[]): Promise<SourceMapper> {
       'An error occurred while processing the sourcemap files' + err
     );
   }
+  mapper.debug();
   return mapper;
 }

--- a/test/test-circular.ts
+++ b/test/test-circular.ts
@@ -71,7 +71,7 @@ maybeDescribe(__filename, () => {
         assert.strictEqual(fileStats.errors().size, 0);
         const jsStats = fileStats.selectStats(/.js$/);
         const mapFiles = fileStats.selectFiles(/.map$/, process.cwd());
-        const mapper = await SourceMapper.create(mapFiles);
+        const mapper = await SourceMapper.create(mapFiles, logger);
         api = debugapi.create(
           logger,
           config,

--- a/test/test-duplicate-expressions.ts
+++ b/test/test-duplicate-expressions.ts
@@ -63,7 +63,7 @@ describe(__filename, () => {
         assert.strictEqual(fileStats.errors().size, 0);
         const jsStats = fileStats.selectStats(/.js$/);
         const mapFiles = fileStats.selectFiles(/.map$/, process.cwd());
-        const mapper = await SourceMapper.create(mapFiles);
+        const mapper = await SourceMapper.create(mapFiles, logger);
         // TODO: Handle the case when mapper is undefined
         // TODO: Handle the case when v8debugapi.create returns null
         api = debugapi.create(

--- a/test/test-duplicate-nested-expressions.ts
+++ b/test/test-duplicate-nested-expressions.ts
@@ -58,7 +58,7 @@ describe(__filename, () => {
         assert.strictEqual(fileStats.errors().size, 0);
         const jsStats = fileStats.selectStats(/.js$/);
         const mapFiles = fileStats.selectFiles(/.map$/, process.cwd());
-        const mapper = await SourceMapper.create(mapFiles);
+        const mapper = await SourceMapper.create(mapFiles, logger);
         // TODO: Handle the case when mapper is undefined
         // TODO: Handle the case when v8debugapi.create returns null
         api = debugapi.create(

--- a/test/test-evaluated-expressions.ts
+++ b/test/test-evaluated-expressions.ts
@@ -41,7 +41,7 @@ describe('debugger provides useful information', () => {
     scanner.scan(config.workingDirectory, /\.js$/).then(async fileStats => {
       const jsStats = fileStats.selectStats(/\.js$/);
       const mapFiles = fileStats.selectFiles(/\.map$/, process.cwd());
-      const mapper = await SourceMapper.create(mapFiles);
+      const mapper = await SourceMapper.create(mapFiles, logger);
       assert(mapper);
       api = debugapi.create(logger, config, jsStats, mapper!);
       done();

--- a/test/test-expression-side-effect.ts
+++ b/test/test-expression-side-effect.ts
@@ -43,7 +43,7 @@ describe('evaluating expressions', () => {
     scanner.scan(config.workingDirectory, /\.js$/).then(async fileStats => {
       const jsStats = fileStats.selectStats(/\.js$/);
       const mapFiles = fileStats.selectFiles(/\.map$/, process.cwd());
-      const mapper = await SourceMapper.create(mapFiles);
+      const mapper = await SourceMapper.create(mapFiles, logger);
       assert(mapper);
       api = debugapi.create(logger, config, jsStats, mapper!);
       done();

--- a/test/test-fat-arrow.ts
+++ b/test/test-fat-arrow.ts
@@ -60,7 +60,7 @@ describe(__filename, () => {
         const jsStats = fileStats.selectStats(/.js$/);
         const mapFiles = fileStats.selectFiles(/.map$/, process.cwd());
         // TODO: Determine if the err parameter should be used.
-        const mapper = await SourceMapper.create(mapFiles);
+        const mapper = await SourceMapper.create(mapFiles, logger);
         // TODO: Handle the case when mapper is undefined
         // TODO: Handle the case when v8debugapi.create returns null
         api = debugapi.create(

--- a/test/test-max-data-size.ts
+++ b/test/test-max-data-size.ts
@@ -47,7 +47,7 @@ describe('maxDataSize', () => {
         assert.strictEqual(fileStats.errors().size, 0);
         const jsStats = fileStats.selectStats(/.js$/);
         const mapFiles = fileStats.selectFiles(/.map$/, process.cwd());
-        const mapper = await SourceMapper.create(mapFiles);
+        const mapper = await SourceMapper.create(mapFiles, logger);
         // TODO: Handle the case when mapper is undefined
         // TODO: Handle the case when v8debugapi.create returns null
         api = debugapi.create(

--- a/test/test-sourcemapper.ts
+++ b/test/test-sourcemapper.ts
@@ -57,25 +57,34 @@ function testTool(
     const logger = new MockLogger();
     let sourcemapper: sm.SourceMapper;
 
-    it('for tool ' + tool + ' sourcemapper should be created correctly',
-       async () => {
-         const start = Date.now();
-         sourcemapper = await sm.create([mapFilePath], logger);
-         assert(
-             Date.now() - start < QUICK_MILLISECONDS,
-             'should create the SourceMapper quickly');
+    it(
+      'for tool ' + tool + ' sourcemapper should be created correctly',
+      async () => {
+        const start = Date.now();
+        sourcemapper = await sm.create([mapFilePath], logger);
+        assert(
+          Date.now() - start < QUICK_MILLISECONDS,
+          'should create the SourceMapper quickly'
+        );
 
-         // Verify if the debugging information is correctly printed.
-         assert.notStrictEqual(
-             logger.debugs[0].args[0].indexOf('debugging information ...'), -1);
-         assert.notStrictEqual(logger.debugs[1].args[0].indexOf('source '), -1);
-         assert.notStrictEqual(
-             logger.debugs[2].args[0].indexOf('outputFile'), -1);
-         assert.notStrictEqual(logger.debugs[3].args[0].indexOf('mapFile'), -1);
-         assert.notStrictEqual(logger.debugs[4].args[0].indexOf('sources'), -1);
-         assert.strictEqual(
-             logger.debugs.length, sourcemapper.infoMap.size * 4 + 1);
-       });
+        // Verify if the debugging information is correctly printed.
+        assert.notStrictEqual(
+          logger.debugs[0].args[0].indexOf('debugging information ...'),
+          -1
+        );
+        assert.notStrictEqual(logger.debugs[1].args[0].indexOf('source '), -1);
+        assert.notStrictEqual(
+          logger.debugs[2].args[0].indexOf('outputFile'),
+          -1
+        );
+        assert.notStrictEqual(logger.debugs[3].args[0].indexOf('mapFile'), -1);
+        assert.notStrictEqual(logger.debugs[4].args[0].indexOf('sources'), -1);
+        assert.strictEqual(
+          logger.debugs.length,
+          sourcemapper.infoMap.size * 4 + 1
+        );
+      }
+    );
 
     it(
       'for tool ' +
@@ -143,17 +152,23 @@ function testTool(
       // Verify if the debugging information is correctly printed.
       const debugsLength = logger.debugs.length;
       assert.notStrictEqual(
-          logger.debugs[debugsLength - 3].args[0].indexOf(
-              'sourcemapper inputPath:'),
-          -1);
+        logger.debugs[debugsLength - 3].args[0].indexOf(
+          'sourcemapper inputPath:'
+        ),
+        -1
+      );
       assert.notStrictEqual(
-          logger.debugs[debugsLength - 2].args[0].indexOf(
-              'sourcemapper sourcePos: {'),
-          -1);
+        logger.debugs[debugsLength - 2].args[0].indexOf(
+          'sourcemapper sourcePos: {'
+        ),
+        -1
+      );
       assert.notStrictEqual(
-          logger.debugs[debugsLength - 1].args[0].indexOf(
-              'sourcemapper mappedPos: {'),
-          -1);
+        logger.debugs[debugsLength - 1].args[0].indexOf(
+          'sourcemapper mappedPos: {'
+        ),
+        -1
+      );
 
       assert.notStrictEqual(
         info,

--- a/test/test-sourcemapper.ts
+++ b/test/test-sourcemapper.ts
@@ -42,6 +42,81 @@ const QUICK_MILLISECONDS = 300;
  *
  *  Note: The line numbers are zero-based
  */
+
+describe('sourcemapper debug info', () => {
+  const logger = new MockLogger();
+  const mapFilePath = path.join(
+    BASE_PATH,
+    path.join('typescript', 'out.js.map')
+  );
+
+  it('should be printed upon creation', async () => {
+    const sourcemapper = await sm.create([mapFilePath], logger);
+
+    // Verify if the debugging information is correctly printed.
+    assert.notStrictEqual(
+      logger.debugs[0].args[0].match('debugging information ...'),
+      null
+    );
+    assert.notStrictEqual(
+      logger.debugs[1].args[0].match(
+        'test/fixtures/sourcemapper/typescript/in.ts'
+      ),
+      null
+    );
+    assert.notStrictEqual(
+      logger.debugs[2].args[0].match(
+        'test/fixtures/sourcemapper/typescript/out.js'
+      ),
+      null
+    );
+    assert.notStrictEqual(
+      logger.debugs[3].args[0].match(
+        'test/fixtures/sourcemapper/typescript/out.js.map'
+      ),
+      null
+    );
+    assert.notStrictEqual(
+      logger.debugs[4].args[0].match('sources: in.ts'),
+      null
+    );
+    assert.strictEqual(logger.debugs.length, sourcemapper.infoMap.size * 4 + 1);
+  });
+
+  it('should be printed when upon get infomap output', async () => {
+    const sourcemapper = await sm.create([mapFilePath], logger);
+    const inputFilePath = path.join(
+      BASE_PATH,
+      path.join('typescript', 'in.ts')
+    );
+
+    const mapInfoInput = sourcemapper.getMapInfoInput(inputFilePath);
+    assert.notEqual(mapInfoInput, null);
+    sourcemapper.getMapInfoOutput(inputFilePath, 1, 0, mapInfoInput!);
+
+    // Verify if the debugging information is correctly printed.
+    const debugsLength = logger.debugs.length;
+    assert.notStrictEqual(
+      logger.debugs[debugsLength - 3].args[0].indexOf(
+        'sourcemapper inputPath:'
+      ),
+      -1
+    );
+    assert.notStrictEqual(
+      logger.debugs[debugsLength - 2].args[0].indexOf(
+        'sourcemapper sourcePos: {'
+      ),
+      -1
+    );
+    assert.notStrictEqual(
+      logger.debugs[debugsLength - 1].args[0].indexOf(
+        'sourcemapper mappedPos: {'
+      ),
+      -1
+    );
+  });
+});
+
 function testTool(
   tool: string,
   relativeMapFilePath: string,
@@ -57,34 +132,14 @@ function testTool(
     const logger = new MockLogger();
     let sourcemapper: sm.SourceMapper;
 
-    it(
-      'for tool ' + tool + ' sourcemapper should be created correctly',
-      async () => {
-        const start = Date.now();
-        sourcemapper = await sm.create([mapFilePath], logger);
-        assert(
-          Date.now() - start < QUICK_MILLISECONDS,
-          'should create the SourceMapper quickly'
-        );
-
-        // Verify if the debugging information is correctly printed.
-        assert.notStrictEqual(
-          logger.debugs[0].args[0].indexOf('debugging information ...'),
-          -1
-        );
-        assert.notStrictEqual(logger.debugs[1].args[0].indexOf('source '), -1);
-        assert.notStrictEqual(
-          logger.debugs[2].args[0].indexOf('outputFile'),
-          -1
-        );
-        assert.notStrictEqual(logger.debugs[3].args[0].indexOf('mapFile'), -1);
-        assert.notStrictEqual(logger.debugs[4].args[0].indexOf('sources'), -1);
-        assert.strictEqual(
-          logger.debugs.length,
-          sourcemapper.infoMap.size * 4 + 1
-        );
-      }
-    );
+    it('for tool ' + tool, async () => {
+      const start = Date.now();
+      sourcemapper = await sm.create([mapFilePath], logger);
+      assert(
+        Date.now() - start < QUICK_MILLISECONDS,
+        'should create the SourceMapper quickly'
+      );
+    });
 
     it(
       'for tool ' +
@@ -148,28 +203,6 @@ function testTool(
         0,
         mapInfoInput!
       );
-
-      // Verify if the debugging information is correctly printed.
-      const debugsLength = logger.debugs.length;
-      assert.notStrictEqual(
-        logger.debugs[debugsLength - 3].args[0].indexOf(
-          'sourcemapper inputPath:'
-        ),
-        -1
-      );
-      assert.notStrictEqual(
-        logger.debugs[debugsLength - 2].args[0].indexOf(
-          'sourcemapper sourcePos: {'
-        ),
-        -1
-      );
-      assert.notStrictEqual(
-        logger.debugs[debugsLength - 1].args[0].indexOf(
-          'sourcemapper mappedPos: {'
-        ),
-        -1
-      );
-
       assert.notStrictEqual(
         info,
         null,

--- a/test/test-sourcemapper.ts
+++ b/test/test-sourcemapper.ts
@@ -58,28 +58,21 @@ describe('sourcemapper debug info', () => {
       logger.debugs[0].args[0].match('debugging information ...'),
       null
     );
-    assert.notStrictEqual(
-      logger.debugs[1].args[0].match(
-        'test/fixtures/sourcemapper/typescript/in.ts'
-      ),
-      null
-    );
-    assert.notStrictEqual(
-      logger.debugs[2].args[0].match(
-        'test/fixtures/sourcemapper/typescript/out.js'
-      ),
-      null
-    );
-    assert.notStrictEqual(
-      logger.debugs[3].args[0].match(
-        'test/fixtures/sourcemapper/typescript/out.js.map'
-      ),
-      null
-    );
-    assert.notStrictEqual(
-      logger.debugs[4].args[0].match('sources: in.ts'),
-      null
-    );
+    const expectedDebugMessages = [
+      'debugging information ...',
+      path.normalize('test/fixtures/sourcemapper/typescript/in.ts'),
+      path.normalize('test/fixtures/sourcemapper/typescript/out.js'),
+      path.normalize('test/fixtures/sourcemapper/typescript/out.js.map'),
+      'sources: in.ts',
+    ];
+
+    for (let i = 0; i < expectedDebugMessages.length; i++) {
+      assert.notStrictEqual(
+        logger.debugs[i].args[0].match(expectedDebugMessages[i]),
+        null,
+        `'${logger.debugs[i].args[0]}' does not match '${expectedDebugMessages[i]}'`
+      );
+    }
     assert.strictEqual(logger.debugs.length, sourcemapper.infoMap.size * 4 + 1);
   });
 
@@ -97,22 +90,22 @@ describe('sourcemapper debug info', () => {
     // Verify if the debugging information is correctly printed.
     const debugsLength = logger.debugs.length;
     assert.notStrictEqual(
-      logger.debugs[debugsLength - 3].args[0].indexOf(
-        'sourcemapper inputPath:'
+      logger.debugs[debugsLength - 3].args[0].match(
+        `sourcemapper inputPath: ${inputFilePath}`
       ),
-      -1
+      null
     );
     assert.notStrictEqual(
-      logger.debugs[debugsLength - 2].args[0].indexOf(
-        'sourcemapper sourcePos: {'
+      logger.debugs[debugsLength - 2].args[0].match(
+        'sourcePos: {"source":"in.ts","line":2,"column":0}'
       ),
-      -1
+      null
     );
     assert.notStrictEqual(
-      logger.debugs[debugsLength - 1].args[0].indexOf(
-        'sourcemapper mappedPos: {'
+      logger.debugs[debugsLength - 1].args[0].match(
+        'mappedPos: {"line":6,"column":0,"lastColumn":null}'
       ),
-      -1
+      null
     );
   });
 });

--- a/test/test-sourcemapper.ts
+++ b/test/test-sourcemapper.ts
@@ -54,10 +54,6 @@ describe('sourcemapper debug info', () => {
     const sourcemapper = await sm.create([mapFilePath], logger);
 
     // Verify if the debugging information is correctly printed.
-    assert.notStrictEqual(
-      logger.debugs[0].args[0].match('debugging information ...'),
-      null
-    );
     const expectedDebugMessages = [
       'debugging information ...',
       path.normalize('test/fixtures/sourcemapper/typescript/in.ts'),
@@ -67,9 +63,12 @@ describe('sourcemapper debug info', () => {
     ];
 
     for (let i = 0; i < expectedDebugMessages.length; i++) {
+      // We use 'indexOf' here instead of 'match' to avoid parsing regular
+      // expression, which will confuse the result when having '\' in the path
+      // name on platform like Windows.
       assert.notStrictEqual(
-        logger.debugs[i].args[0].match(expectedDebugMessages[i]),
-        null,
+        logger.debugs[i].args[0].indexOf(expectedDebugMessages[i]),
+        -1,
         `'${logger.debugs[i].args[0]}' does not match '${expectedDebugMessages[i]}'`
       );
     }
@@ -88,24 +87,27 @@ describe('sourcemapper debug info', () => {
     sourcemapper.getMapInfoOutput(inputFilePath, 1, 0, mapInfoInput!);
 
     // Verify if the debugging information is correctly printed.
+    // We use 'indexOf' here instead of 'match' to avoid parsing regular
+    // expression, which will confuse the result when having '\' in the path
+    // name on platform like Windows.
     const debugsLength = logger.debugs.length;
     assert.notStrictEqual(
-      logger.debugs[debugsLength - 3].args[0].match(
+      logger.debugs[debugsLength - 3].args[0].indexOf(
         `sourcemapper inputPath: ${inputFilePath}`
       ),
-      null
+      -1
     );
     assert.notStrictEqual(
-      logger.debugs[debugsLength - 2].args[0].match(
+      logger.debugs[debugsLength - 2].args[0].indexOf(
         'sourcePos: {"source":"in.ts","line":2,"column":0}'
       ),
-      null
+      -1
     );
     assert.notStrictEqual(
-      logger.debugs[debugsLength - 1].args[0].match(
+      logger.debugs[debugsLength - 1].args[0].indexOf(
         'mappedPos: {"line":6,"column":0,"lastColumn":null}'
       ),
-      null
+      -1
     );
   });
 });

--- a/test/test-this-context.ts
+++ b/test/test-this-context.ts
@@ -58,7 +58,7 @@ describe(__filename, () => {
         assert.strictEqual(fileStats.errors().size, 0);
         const jsStats = fileStats.selectStats(/.js$/);
         const mapFiles = fileStats.selectFiles(/.map$/, process.cwd());
-        const mapper = await SourceMapper.create(mapFiles);
+        const mapper = await SourceMapper.create(mapFiles, logger);
         // TODO: Handle the case when mapper is undefined
         // TODO: Handle the case when v8debugapi.create returns null
         api = debugapi.create(

--- a/test/test-try-catch.ts
+++ b/test/test-try-catch.ts
@@ -57,7 +57,7 @@ describe(__filename, () => {
         assert.strictEqual(fileStats.errors().size, 0);
         const jsStats = fileStats.selectStats(/.js$/);
         const mapFiles = fileStats.selectFiles(/.map$/, process.cwd());
-        const mapper = await SourceMapper.create(mapFiles);
+        const mapper = await SourceMapper.create(mapFiles, logger);
         // TODO: Handle the case when mapper is undefined
         // TODO: Handle the case when v8debugapi.create returns null
         api = debugapi.create(

--- a/test/test-v8debugapi.ts
+++ b/test/test-v8debugapi.ts
@@ -178,7 +178,7 @@ describe('debugapi selection', () => {
         assert.strictEqual(fileStats.errors().size, 0);
         const jsStats = fileStats.selectStats(/.js$/);
         const mapFiles = fileStats.selectFiles(/.js.map$/, process.cwd());
-        const mapper = await SourceMapper.create(mapFiles);
+        const mapper = await SourceMapper.create(mapFiles, logger);
         // TODO(dominickramer): Handle the case when mapper is undefined.
         // TODO(dominickramer): Handle the case when v8debugapi.create
         // returns null
@@ -222,7 +222,7 @@ describeFn('debugapi selection on Node >=10', () => {
         assert.strictEqual(fileStats.errors().size, 0);
         const jsStats = fileStats.selectStats(/.js$/);
         const mapFiles = fileStats.selectFiles(/.js.map$/, process.cwd());
-        const mapper = await SourceMapper.create(mapFiles);
+        const mapper = await SourceMapper.create(mapFiles, logger);
         assert(mapper);
         api = debugapi.create(logger, config, jsStats, mapper!);
         // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -250,7 +250,7 @@ describe('v8debugapi', () => {
           assert.strictEqual(fileStats.errors().size, 0);
           const jsStats = fileStats.selectStats(/.js$|.jsz$/);
           const mapFiles = fileStats.selectFiles(/.js.map$/, process.cwd());
-          const mapper = await SourceMapper.create(mapFiles);
+          const mapper = await SourceMapper.create(mapFiles, logger);
 
           // TODO(dominickramer): Handle the case when mapper is undefined.
           // TODO(dominickramer): Handle the case when v8debugapi.create

--- a/test/test-v8debugapi.ts
+++ b/test/test-v8debugapi.ts
@@ -766,41 +766,7 @@ describe('v8debugapi', () => {
       assert(stateIsClean(api));
     });
 
-    it('should only attach to v8 when having active breakpoints', done => {
-      // The test is only eligible for the InspectorDebugApi test target.
-      if (!(api instanceof InspectorDebugApi)) {
-        done();
-        return;
-      }
-
-      const inspectorDebugApi = api as InspectorDebugApi;
-      assert.strictEqual(inspectorDebugApi.inspector.session, null);
-
-      const bp: stackdriver.Breakpoint = {
-        id: breakpointInFoo.id,
-        location: breakpointInFoo.location,
-        action: 'LOG',
-        logMessageFormat: 'cat',
-      } as {} as stackdriver.Breakpoint;
-      api.set(bp, err1 => {
-        assert.ifError(err1);
-        api.log(
-          bp,
-          () => {},
-          () => false
-        );
-
-        assert.notStrictEqual(inspectorDebugApi.inspector.session, null);
-
-        api.clear(bp, err2 => {
-          assert.ifError(err2);
-          assert.strictEqual(inspectorDebugApi.inspector.session, null);
-          done();
-        });
-      });
-    });
-
-    it('should reset v8 debugging session when meeting threshold', done => {
+    it('should perform v8 breakpoints reset when meeting threshold', done => {
       // The test is only eligible for the InspectorDebugApi test target.
       if (!(api instanceof InspectorDebugApi)) {
         done();
@@ -826,7 +792,7 @@ describe('v8debugapi', () => {
         );
 
         const inspectorDebugApi = api as InspectorDebugApi;
-        const v8SessionBeforeReset = inspectorDebugApi.inspector.session;
+        const v8BeforeReset = inspectorDebugApi.v8;
 
         // The loop should trigger the breakpoints reset.
         for (let i = 0; i < config.resetV8DebuggerThreshold; i++) {
@@ -834,13 +800,9 @@ describe('v8debugapi', () => {
         }
 
         // Expect the current v8 data is no longer the previous one.
-        assert.notStrictEqual(
-          inspectorDebugApi.inspector.session,
-          v8SessionBeforeReset
-        );
+        assert.notStrictEqual(inspectorDebugApi.v8, v8BeforeReset);
 
-        // Make sure the logpoint is still triggered correctly after the second
-        // reset.
+        // Make sure the logpoint is still triggered correctly after the second reset.
         for (let i = 0; i < config.resetV8DebuggerThreshold + 1; i++) {
           code.foo(1);
         }


### PR DESCRIPTION
This PR is to add debugging information to source mapper so that it is easier to debug related issues from users.

Fixes #932
