### PR TITLE
fix: Add more debugging info to the system e2e test

### DIFF
--- a/system-test/test-e2e.ts
+++ b/system-test/test-e2e.ts
@@ -68,7 +68,7 @@ describe('@google-cloud/debug end-to-end behavior', () => {
         debuggeeId: string;
         projectId: string;
       }) => {
-        console.log(c);
+        console.log('handler received:', c);
         if (c.error) {
           reject(new Error('A child reported the following error: ' + c.error));
           return;
@@ -91,6 +91,7 @@ describe('@google-cloud/debug end-to-end behavior', () => {
         }
         numChildrenReady++;
         if (numChildrenReady === CLUSTER_WORKERS) {
+          console.log('All children are ready');
           resolve();
         }
       };
@@ -105,7 +106,7 @@ describe('@google-cloud/debug end-to-end behavior', () => {
       };
 
       for (let i = 0; i < CLUSTER_WORKERS; i++) {
-        // Fork child processes that sned messages to this process with IPC.
+        // Fork child processes that send messages to this process with IPC.
         // We pass UUID to the children so that they can all get the same
         // debuggee id.
         const child: Child = {transcript: ''};
@@ -126,8 +127,8 @@ describe('@google-cloud/debug end-to-end behavior', () => {
   afterEach(function () {
     this.timeout(5 * 1000);
     // Create a promise for each child that resolves when that child exits.
-    const childExitPromises = children.map(child => {
-      console.log(child.transcript);
+    const childExitPromises = children.map((child, index) => {
+      console.log(`child ${index} transcript: ===#`, child.transcript, '#===');
       assert(child.process);
       const childProcess = child.process as cp.ChildProcess;
       childProcess.kill();
@@ -164,7 +165,7 @@ describe('@google-cloud/debug end-to-end behavior', () => {
     assert.ok(debuggees, 'should get a valid ListDebuggees response');
 
     const result = debuggees.find(d => d.id === debuggeeId);
-    assert.ok(result, 'should find the debuggee we just registered');
+    assert.ok(result, `should find the debuggee we just registered, expected debuggeeId: ${debuggeeId}, found: ${result}`);
   }
 
   async function verifyDeleteBreakpoints() {

--- a/system-test/test-e2e.ts
+++ b/system-test/test-e2e.ts
@@ -165,7 +165,10 @@ describe('@google-cloud/debug end-to-end behavior', () => {
     assert.ok(debuggees, 'should get a valid ListDebuggees response');
 
     const result = debuggees.find(d => d.id === debuggeeId);
-    assert.ok(result, `should find the debuggee we just registered, expected debuggeeId: ${debuggeeId}, found: ${result}`);
+    assert.ok(
+      result,
+      `should find the debuggee we just registered, expected debuggeeId: ${debuggeeId}, found: ${result}`
+    );
   }
 
   async function verifyDeleteBreakpoints() {

--- a/test/fixtures/fib.js
+++ b/test/fixtures/fib.js
@@ -29,6 +29,8 @@ nocks.metadataInstance();
 
 const UUID = process.argv[2] || uuid.v4();
 
+console.log('UUID: ', UUID);
+
 // eslint-disable-next-line node/no-missing-require
 const debuglet = require('../../..').start({
   debug: {


### PR DESCRIPTION
The e2e test did not seem to fail in the past several months. We tend to close the issue for now with this PR, which adds more debugging information to the e2e test, so that if it failed again in the future, we would have more information to know what's the cause.

Fixes #946
