### PR TITLE
fix: do not throw when meeting empty source map file

### DIFF
--- a/src/agent/io/sourcemapper.ts
+++ b/src/agent/io/sourcemapper.ts
@@ -158,10 +158,6 @@ async function processSourcemap(
       return path.normalize(path.join(parentDir, relPath));
     });
 
-  if (normalizedSourcesRelToProc.length === 0) {
-    throw new Error('No sources listed in the sourcemap file ' + mapPath);
-  }
-
   for (const src of normalizedSourcesRelToProc) {
     const inputFile = path.normalize(src);
     infoMap.set(inputFile, {

--- a/test/fixtures/sourcemaps/empty-source-map.js.map
+++ b/test/fixtures/sourcemaps/empty-source-map.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":[],"names":[],"mappings":"","sourcesContent":[],"file":"js-file.js"}

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -122,7 +122,6 @@ describe('Debuglet', () => {
       const mapFiles = searchResults.mapFiles.sort();
       assert(mapFiles[0].endsWith('empty-source-map.js.map'));
       assert(mapFiles[1].endsWith('js-map-file.js.map'));
-
     });
   });
 

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -112,12 +112,17 @@ describe('Debuglet', () => {
       const config = extend({}, defaultConfig, {
         workingDirectory: SOURCEMAP_DIR,
       });
+
       const searchResults = await Debuglet.findFiles(config, 'fake-id');
       assert(searchResults.jsStats);
       assert.strictEqual(Object.keys(searchResults.jsStats).length, 1);
       assert(searchResults.jsStats[path.join(SOURCEMAP_DIR, 'js-file.js')]);
-      assert.strictEqual(searchResults.mapFiles.length, 1);
-      assert(searchResults.mapFiles[0].endsWith('js-map-file.js.map'));
+
+      assert.strictEqual(searchResults.mapFiles.length, 2);
+      const mapFiles = searchResults.mapFiles.sort();
+      assert(mapFiles[0].endsWith('empty-source-map.js.map'));
+      assert(mapFiles[1].endsWith('js-map-file.js.map'));
+
     });
   });
 


### PR DESCRIPTION
The debugger agent should not throw when meeting empty source map files, so that when there are such source map files, the agent can still start normally.

Fixes #989
