### PR TITLE
fix(deps): Update source-map to 0.8.0-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "gcp-metadata": "^4.0.0",
     "p-limit": "^3.0.1",
     "semver": "^7.0.0",
-    "source-map": "^0.7.3",
+    "source-map": "^0.8.0-beta.0",
     "split": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
source-map 0.7.3 is incompatible with newer versions of node.  Temporarily switch to 0.8.0-beta.0 until either a new release of source-map is available, or until we migrate to an alternative implementation.

Fixes #1066