### PR TITLE
chore: fix presubmit failures by adjusting docs and pinning a system-test dependency

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -70,8 +70,8 @@ body: |-
   ```
 
   The following params are optional:
-  * firebaseDbUrl - https://PROJECT_ID-cdbg.firebase.io.com will be used if not
-    provided. where PROJECT_ID is your project ID.
+  * firebaseDbUrl - https://**PROJECT_ID**-cdbg.firebaseio.com will be used if not
+    provided. where **PROJECT_ID** is your project ID.
   * firebaseKeyPath - Default google application credentials are used if not
     provided.
 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ require('@google-cloud/debug-agent').start({
 ```
 
 The following params are optional:
-* firebaseDbUrl - https://PROJECT_ID-cdbg.firebase.io.com will be used if not
-  provided. where PROJECT_ID is your project ID.
+* firebaseDbUrl - https://**PROJECT_ID**-cdbg.firebaseio.com will be used if not
+  provided. where **PROJECT_ID** is your project ID.
 * firebaseKeyPath - Default google application credentials are used if not
   provided.
 

--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -3,8 +3,7 @@
   "skip": [
     "https://codecov.io/gh/googleapis/",
     "www.googleapis.com",
-    "img.shields.io",
-    "https://project_id-cdbg.firebase.io.com"
+    "img.shields.io"
   ],
   "silent": true,
   "concurrency": 10

--- a/system-test/fixtures/sample/package.json
+++ b/system-test/fixtures/sample/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "gts": "^2.0.0",
-    "typescript": "^3.8.3",
+    "typescript": "4.8.4",
     "@types/node": "^16.0.0"
   }
 }


### PR DESCRIPTION
ci/kokoro: System test is broken without this change.

Newer versions of typescript prevent express-serve-static-core from building properly, which blocks PRs in this repo from being submitted.  Given the fact that the typescript version is largely irrelevant for the sample app, this pinning to a specific version is the simplest way to unblock submission of PRs.

Also includes quick change to make the readme easier to read and to help out linkinator, without which ci/docs will fail.
