### PR TITLE
fix: correctly send labels on register calls.

### DIFF
--- a/src/agent/firebase-controller.ts
+++ b/src/agent/firebase-controller.ts
@@ -169,7 +169,7 @@ export class FirebaseController implements Controller {
     debuggee.id = this.debuggeeId;
 
     const debuggeeRef = this.db.ref(`cdbg/debuggees/${this.debuggeeId}`);
-    debuggeeRef.set(debuggee, err => {
+    debuggeeRef.set(debuggee as {}, err => {
       if (err) {
         callback(err);
       } else {

--- a/test/test-firebase-controller.ts
+++ b/test/test-firebase-controller.ts
@@ -183,6 +183,40 @@ describe('Firebase Controller', () => {
         done();
       });
     });
+    it('should pass labels properly', done => {
+      const db = new MockDatabase();
+      // Debuggee Id is based on the sha1 hash of the json representation of
+      // the debuggee.
+      const debuggeeId = 'd-cbd029da';
+      const debuggeeWithLabels = new Debuggee({
+        project: 'fake-project',
+        uniquifier: 'fake-id',
+        description: 'unit test',
+        agentVersion: 'SomeName/client/SomeVersion',
+        labels: {
+          V8_version: 'v8_version',
+          process_title: 'node',
+          projectid: 'fake-project',
+          agent_version: '7.x',
+          version: 'appengine_version',
+          minorversion: 'minor_version',
+        },
+      });
+
+      const controller = new FirebaseController(
+        db as {} as firebase.database.Database
+      );
+      controller.register(debuggeeWithLabels, (err, result) => {
+        assert(!err, 'not expecting an error');
+        assert.ok(result);
+        assert.strictEqual(result!.debuggee.id, debuggeeId);
+        assert.strictEqual(
+          db.mockRef(`cdbg/debuggees/${debuggeeId}`).value,
+          debuggeeWithLabels
+        );
+        done();
+      });
+    });
     it('should error out gracefully', done => {
       const db = new MockDatabase();
       // Debuggee Id is based on the sha1 hash of the json representation of


### PR DESCRIPTION
Debuggee labels were not being sent to the firebase rtdb when registering.  This resulted in debuggees without adequate information to identify them using the snapshot debugger cli.  There was no functional difference otherwise.
