### PR TITLE
fix: correctly propagate the firebase app name

### DIFF
--- a/src/agent/firebase-controller.ts
+++ b/src/agent/firebase-controller.ts
@@ -98,11 +98,11 @@ export class FirebaseController implements Controller {
         {
           databaseURL: databaseUrl,
         },
-        'cdbg'
+        FIREBASE_APP_NAME
       );
     }
 
-    const db = firebase.database();
+    const db = firebase.database(app);
 
     // Test the connection by reading the schema version.
     try {


### PR DESCRIPTION
The firebase app name is not being correctly set and in at least some cases will prevent the debug agent from connecting to the firebase database.